### PR TITLE
Fix formatting after line maxWidth changed to 120

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,21 +1,8 @@
 module.exports = {
   bracketSpacing: true,
+  parser: 'typescript',
   printWidth: 120,
   singleQuote: true,
   trailingComma: 'es5',
-  useTabs: false,
-  overrides: [
-    {
-      files: '*.ts',
-      options: {
-        parser: 'typescript'
-      }
-    },
-    {
-      files: '*.sol',
-      options: {
-        singleQuote: false
-      }
-    }
-  ]
+  useTabs: false
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,7 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to reload.
         </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a className="App-link" href="https://reactjs.org" target="_blank" rel="noopener noreferrer">
           Learn React
         </a>
       </header>

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,11 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,5 +19,5 @@ reportWebVitals();
 // These are injected by fleek (our IPFS hosting service).
 // See README.md for more information.
 if (process.env.REACT_APP_NODE_ENV! === 'staging') {
-  console.log('You are browsing a staging environment!')
+  console.log('You are browsing a staging environment!');
 }


### PR DESCRIPTION
Since we only lint changed files, when I changed the maxWidth in prettier it changed formatting settings, but I didn't change any JS files :)

* Also removed unnecessary prettier configuration. We will likely never use solidity files.
