### PR TITLE
Multiply vote slider percentages by 100

### DIFF
--- a/src/logic/proposals/selectors.ts
+++ b/src/logic/proposals/selectors.ts
@@ -6,8 +6,8 @@ import { HUNDRED_PERCENT } from '../../contracts';
 export type ProposalStatus = 'Passing' | 'Failing' | 'Executed' | 'Execute' | 'Rejected';
 export const voteSliderSelector = (proposal: Proposal) => {
   const minAcceptanceQuorum = proposal.minAcceptQuorum.toNumber();
-  const forPercentage = computePercentage(proposal.yea, proposal.votingPower);
-  const againstPercentage = computePercentage(proposal.nay, proposal.votingPower);
+  const forPercentage = computePercentage(proposal.yea, proposal.votingPower, true);
+  const againstPercentage = computePercentage(proposal.nay, proposal.votingPower, true);
 
   const computeProposalStatus = (): ProposalStatus => {
     // NOTE: We rely on proposal.supportRequired to be 50% because we don't expect it to change


### PR DESCRIPTION
Function `computePercentages` returns value in interval <0,1>, but we want the "human readable" format, which is this numbe multiplied by 100.