### PR TITLE
Fix app crash after initiate unstake

### DIFF
--- a/src/pages/dashboard/dashboard.tsx
+++ b/src/pages/dashboard/dashboard.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useChainData } from '../../chain-data';
 import { useApi3Pool } from '../../contracts';
 import { pendingUnstakeSelector, tokenBalancesSelector, useLoadDashboardData } from '../../logic/dashboard';
-import { formatAndRoundApi3, UNKNOWN_NUMBER } from '../../utils';
+import { formatAndRoundApi3, goSync, isGoSuccess, UNKNOWN_NUMBER } from '../../utils';
 import TokenAmountForm from './forms/token-amount-form';
 import TokenDepositForm from './forms/token-deposit-form';
 import Layout from '../../components/layout/layout';
@@ -179,24 +179,23 @@ const Dashboard = () => {
         />
       </Modal>
       <Modal open={openModal === 'confirm-unstake'} onClose={closeModal}>
-        {/* NOTE: Prevent react executing the component if not opened, otherwise BigNumber.from might throw */}
-        {openModal === 'confirm-unstake' && (
-          <ConfirmUnstakeForm
-            title={`Are you sure you would like to unstake ${inputValue} tokens?`}
-            onConfirm={async (parsedValue: BigNumber) => {
-              if (!api3Pool || !data) return;
-              const userShares = parsedValue.mul(data.totalShares).div(data.totalStake);
-              const tx = await api3Pool.scheduleUnstake(userShares);
-              setChainData('Save initiate unstake transaction', {
-                transactions: [...transactions, { type: 'initiate-unstake', tx }],
-              });
-            }}
-            // We expect the inputValue to be validated by previous form
-            amount={BigNumber.from(inputValue)}
-            onChange={setInputValue}
-            onClose={closeModal}
-          />
-        )}
+        <ConfirmUnstakeForm
+          title={`Are you sure you would like to unstake ${inputValue} tokens?`}
+          onConfirm={async (parsedValue: BigNumber) => {
+            if (!api3Pool || !data) return;
+            const userShares = parsedValue.mul(data.totalShares).div(data.totalStake);
+            const tx = await api3Pool.scheduleUnstake(userShares);
+            setChainData('Save initiate unstake transaction', {
+              transactions: [...transactions, { type: 'initiate-unstake', tx }],
+            });
+          }}
+          // We expect the inputValue to be validated by previous form
+          // but once the form is closed and the field is reset it might throw
+          amount={
+            isGoSuccess(goSync(() => BigNumber.from(inputValue))) ? BigNumber.from(inputValue) : BigNumber.from(0)
+          }
+          onClose={closeModal}
+        />
       </Modal>
     </Layout>
   );

--- a/src/pages/dashboard/forms/confirm-unstake-form.tsx
+++ b/src/pages/dashboard/forms/confirm-unstake-form.tsx
@@ -11,7 +11,6 @@ interface Props {
   amount: BigNumber;
   onConfirm: (parsedInput: BigNumber) => Promise<any>;
   onClose: () => void;
-  onChange: (input: string) => void;
   closeOnConfirm?: boolean;
 }
 


### PR DESCRIPTION
I accidentally broke the initiate unstake after making the refactor to split the token amount form in https://github.com/api3dao/api3-dao-dashboard/commit/f4371ba1a837dc9691fbda11f45c641ffe996d57

The problem is that when we reset the value, the `BigNumber.from(inputValue)` fails... One possible fix is to first close the modal and only then reset the input value, but I don't like that. Instead, let's make sure the modal doesn't throw an error.