### PR TITLE
Make the API3 logo clickable and link to the staking page

### DIFF
--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import SignIn from '../sign-in/sign-in';
 import Menu from '../menu/menu';
 import { images } from '../../utils';
@@ -7,7 +8,9 @@ const Navigation = () => {
   return (
     <div className={styles.navigation}>
       <div className={styles.navigationMenu}>
-        <img src={images.api3LogoWhite} alt="logo" height="36" width="116" />
+        <Link to="/dashboard">
+          <img src={images.api3LogoWhite} alt="logo" height="36" width="116" />
+        </Link>
         <Menu />
       </div>
       <SignIn position="navigation" />


### PR DESCRIPTION
### Description

Quick fix to make the API3 logo clickable and redirect to the `/dashboard` page. I'm not sure that we want to "reload the app"? Normally the logo redirects to the home/initial page.

### Addresses

https://github.com/api3dao/api3-dao-dashboard/issues/132