### PR TITLE
Filter out the user's IP address and user agent

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,18 @@ if (process.env.REACT_APP_SENTRY_DSN && process.env.REACT_APP_NODE_ENV) {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     environment: process.env.REACT_APP_NODE_ENV,
+    integrations(integrations) {
+      return integrations.filter((integration) => {
+        // Integrations can be filtered out here
+        // See: https://docs.sentry.io/platforms/javascript/configuration/integrations/default/
+        return !['UserAgent'].includes(integration.name);
+      });
+    },
+    beforeSend(event) {
+      // Do not collect the user's IP address
+      event.user = { ip_address: '0.0.0.0' };
+      return event;
+    },
   });
 }
 


### PR DESCRIPTION
I spent some more time digging into Sentry's documentation. It seems like we can actually filter out the user agent (browser and OS) and then overwrite the user's IP address so it doesn't show in Sentry.

As you can see in the screenshot below, no user identifying information is present. We can filter out other integrations like breadcrumbs too if necessary

![sentry-dev](https://user-images.githubusercontent.com/4114009/123514808-ffcc1200-d694-11eb-8d6c-045f9109516d.png)
