### PR TITLE
Minor fixes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -16,7 +16,7 @@ function App() {
       <PageContainer>
         <Router>
           <Switch>
-            <Route path="/proposals/:typeAndId" exact>
+            <Route path="/governance/:typeAndId" exact>
               <ProposalDetails />
             </Route>
             <Route path="/governance" exact>

--- a/src/chain-data/helpers.ts
+++ b/src/chain-data/helpers.ts
@@ -36,6 +36,8 @@ export const getNetworkData = async (provider: ethers.providers.Web3Provider | n
   // to localhost. The network name is needed to display the "Unsupported Network"
   // message to the user if required and in "connected to" status panel.
   if (networkName === 'unknown') networkName = 'localhost';
+  // Convert "homestead" to mainnet for convenience
+  if (networkName === 'homestead') networkName = 'mainnet';
 
   const networdData: Partial<ChainData> = {
     provider,

--- a/src/components/sign-in/sign-in.tsx
+++ b/src/components/sign-in/sign-in.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { ethers } from 'ethers';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import Web3Modal from 'web3modal';
@@ -171,7 +171,7 @@ const SignIn = ({ dark, position }: Props) => {
     // Disable localhost network on non-development environment
     if (process.env.REACT_APP_NODE_ENV !== 'development' && name === 'localhost') return false;
     else return true;
-  }).join(', ');
+  });
   const isSupportedNetwork = !isSignedIn || supportedNetworks.includes(networkName);
 
   return (
@@ -194,12 +194,22 @@ const SignIn = ({ dark, position }: Props) => {
           <img className={styles.unsupportedNetworkIcon} src={images.unsupportedNetwork} alt="network not supported" />
           <h5>Unsupported chain!</h5>
 
-          <p className={globalStyles.mtXl}>Supported networks are: {supportedNetworks}</p>
+          <p className={globalStyles.mtXl}>
+            Supported networks:{' '}
+            {supportedNetworks
+              .map((network) => <b>{network}</b>)
+              .map((Component, i) => (
+                <Fragment key={i}>
+                  {i !== 0 && ', '}
+                  {Component}
+                </Fragment>
+              ))}
+          </p>
           <p className={globalStyles.mtXl}>
             Current network: <b>{networkName}</b>
           </p>
 
-          <p className={globalStyles.mtXl}>Please use your wallet and connect to one of the supported networks</p>
+          <p className={globalStyles.mtXl}>Please connect your wallet to a supported network.</p>
         </div>
       </GenericModal>
     </>

--- a/src/pages/history/history.tsx
+++ b/src/pages/history/history.tsx
@@ -44,7 +44,7 @@ const History = () => {
       <BorderedBox
         header={
           <div className={styles.borderBoxHeader}>
-            <h5>Proposals</h5>
+            <h5>Past proposals</h5>
             <div>
               <Button
                 onClick={() => applyHistoryFilter('primary')}

--- a/src/pages/proposal-commons/proposal-list/proposal-list.tsx
+++ b/src/pages/proposal-commons/proposal-list/proposal-list.tsx
@@ -38,6 +38,8 @@ const ProposalInfoState = ({ proposal, device }: ProposalProps) => {
       ? `Primary-type proposals need ${proposal.minAcceptQuorum}% quorum to pass`
       : `Secondary-type proposals need ${proposal.minAcceptQuorum}% quorum to pass`;
 
+  const proposalId = `#${voteIdFormat(proposal.voteId)} ${proposal.type}`;
+
   return (
     <div
       className={classNames(styles.proposalItemBox, {
@@ -45,12 +47,11 @@ const ProposalInfoState = ({ proposal, device }: ProposalProps) => {
         [styles.mobile]: device === 'mobile',
       })}
     >
-      <p className={styles.proposalItemVoteId}>#{voteIdFormat(proposal.voteId)}</p>
       <ProposalStatus proposal={proposal} />
       <div className={styles.proposalItemTag}>
         <Tooltip overlay={tooltipContent}>
           <Tag type={proposal.type}>
-            <span className={globalStyles.capitalize}>{proposal.type}</span>
+            <span className={globalStyles.capitalize}>{proposalId}</span>
           </Tag>
         </Tooltip>
       </div>

--- a/src/pages/proposal-commons/proposal-list/proposal-list.tsx
+++ b/src/pages/proposal-commons/proposal-list/proposal-list.tsx
@@ -76,7 +76,7 @@ const ProposalList = (props: Props) => {
       {proposals?.map((p) => {
         const votingSliderData = voteSliderSelector(p);
         const navlink = {
-          base: p.open ? 'proposals' : 'history',
+          base: p.open ? 'governance' : 'history',
           typeAndId: encodeProposalTypeAndId(p.type, voteIdFormat(p.voteId)),
         };
 

--- a/src/pages/proposals/proposals.tsx
+++ b/src/pages/proposals/proposals.tsx
@@ -110,7 +110,7 @@ const Proposals = () => {
       <BorderedBox
         header={
           <Header>
-            <h5>Proposals</h5>
+            <h5>Active proposals</h5>
             <div>
               <Button onClick={() => setOpenNewProposalModal(true)} size="large" disabled={!canCreateNewProposal}>
                 + New proposal


### PR DESCRIPTION
## Includes

* Rename active proposal path from `proposal` to `governance`, because otherwise the navigation button won't be highlighted. This also matches the convention for history page.
* Rename proposals to `active proposals` or `past proposals`
* Minor changes to unsupported network modal