### PR TITLE
WIP: voting error handling

### DIFF
--- a/src/contracts/helpers.ts
+++ b/src/contracts/helpers.ts
@@ -56,4 +56,5 @@ export const isZeroAddress = (address: string) => address === constants.AddressZ
 // export const EPOCH_LENGTH = 7 * 24 * 60 * 60;
 
 // Temporary value for user tests
-export const EPOCH_LENGTH = 60 * 60;
+// export const EPOCH_LENGTH = 60 * 60;
+export const EPOCH_LENGTH = 60;

--- a/src/pages/proposals/proposals.tsx
+++ b/src/pages/proposals/proposals.tsx
@@ -129,11 +129,7 @@ const Proposals = () => {
         noMobileBorders
       />
       <Modal open={openNewProposalModal} onClose={() => setOpenNewProposalModal(false)} size="large">
-        <NewProposalForm
-          onClose={() => setOpenNewProposalModal(false)}
-          onConfirm={onCreateProposal}
-          api3Agent={api3Agent!}
-        />
+        <NewProposalForm onConfirm={onCreateProposal} />
       </Modal>
     </Layout>
   );


### PR DESCRIPTION
Call static doesn't seem to work for me...

I tried setting the epoch length to one minute just for convenience (in both contract and localhost).
I used one account and I staked some tokens and I am the only staker (so I have absolute majority votin power).
This means every proposal I create automatically executes on creation...
I am trying to play and modify stake target, and I can do that every minute If I disable the `.callstatic` check

However, when the check is enabled I can't create a new proposal and I am getting `API3_HIT_PROPOSAL_COOLDOWN` not sure why... @andreogle do you have any idea why this happens?