### PR TITLE
Prevent negative numbers and hide genesis epoch checklist item

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -15,9 +15,18 @@ type Props = {
   id?: string;
   block?: boolean;
   autoFocus?: boolean;
+  allowNegative?: boolean;
 };
 
-const Input = ({ size = 'normal', type = 'text', block, autosize, disabled, ...componentProps }: Props) => {
+const Input = ({
+  size = 'normal',
+  type = 'text',
+  block,
+  autosize,
+  disabled,
+  allowNegative,
+  ...componentProps
+}: Props) => {
   const CustomNumberInput = useCallback(
     (props: any) => {
       return (
@@ -69,6 +78,7 @@ const Input = ({ size = 'normal', type = 'text', block, autosize, disabled, ...c
           })}
           {...componentProps}
           customInput={AutosizeInput}
+          allowNegative={allowNegative || false}
           decimalScale={18}
         />
       )}

--- a/src/pages/proposals/proposals.tsx
+++ b/src/pages/proposals/proposals.tsx
@@ -62,11 +62,12 @@ const Proposals = () => {
           ? `You need at least ${thresholdPowerText}% of the total vote representation to post a proposal. You represent ${votingPowerText}% of the total voting power${delegatedPowerText}.`
           : 'You need to have enough voting power.',
     },
-    {
-      checked: createNewProposal?.genesisEpochOver ?? false,
-      label: 'The genesis epoch is over.',
-    },
   ];
+
+  // Only display this message during the genesis epoch
+  if (createNewProposal?.genesisEpochOver) {
+    newProposalChecklistItems.unshift({ checked: false, label: 'The genesis epoch is over.' });
+  }
 
   // The button should always be in sync with the checklist
   const canCreateNewProposal = newProposalChecklistItems.every((item) => item.checked);


### PR DESCRIPTION
### Changes

1. Number inputs now completely prevent negative numbers from being entered by default. Number inputs are only used on the dashboard modals and as the "ETH value" when creating a new proposal, so this shouldn't cause any issues
2. Only display the "The genesis epoch is over." tooltip item during the genesis epoch, after which it will always be hidden (but still validated)

### Addresses

https://github.com/api3dao/api3-dao-dashboard/issues/184