### PR TITLE
Do not send handled errors to sentry anymore

### DIFF
--- a/src/components/notifications/notifications.tsx
+++ b/src/components/notifications/notifications.tsx
@@ -29,7 +29,7 @@ interface ToastProps {
 
 interface ErrorToastProps extends ToastProps {
   errorOrMessage: Error | string;
-  skipSentry?: boolean;
+  sendToSentry?: boolean;
 }
 
 interface ToastPropsWithType extends ToastProps {
@@ -87,8 +87,8 @@ export const warning = throttle(
 
 export const error = throttle(
   (props: ErrorToastProps, overrides?: ToastOptions) => {
-    const { skipSentry = false, errorOrMessage, ...other } = props;
-    if (!skipSentry) {
+    const { sendToSentry = false, errorOrMessage, ...other } = props;
+    if (sendToSentry) {
       if (typeof errorOrMessage === 'string') Sentry.captureMessage(errorOrMessage);
       else Sentry.captureException(errorOrMessage);
     }


### PR DESCRIPTION
My motivation for sending even the handled errors was to have better understanding what issues will our users have.
This turned out pretty well, but now the issues keep repeating and they are polluting the sentry dashboard (and we can do nothing about them since they are handled already).

In this PR, I'm changing this to only don't send these errors by default.