### PR TITLE
Force a new block after increasing the time

### DIFF
--- a/hardhat/scripts/next-epoch.ts
+++ b/hardhat/scripts/next-epoch.ts
@@ -4,6 +4,9 @@ import { EPOCH_LENGTH } from '../../src/contracts/helpers';
 async function main() {
   await ethers.provider.send('evm_increaseTime', [EPOCH_LENGTH]); // move the time to the next epoch
   console.info(`NOTE: You may need to reset your metamask wallet after the command completes`);
+
+  // Force a new block as the 'isGenesisEpoch' check depends on the timestamp of the current block
+  await ethers.provider.send('evm_mine', []);
 }
 
 main()


### PR DESCRIPTION
### Description

I was having an issue when testing creating proposals where the "genesis epoch is over" check was still disabling the button, even after running the `next-epoch.ts` script. I did a bit of digging and it seems like simply increasing the time is not enough. We also need to mine a new block as the [isGenesisEpoch() function](https://github.com/api3dao/api3-dao/blob/c745454d60ad97f6ffa9b5aa612c9a2b7eba16d0/packages/pool/contracts/StateUtils.sol#L418-L425) looks at the current block's timestamp.

The issue can be replicated by doing the following steps in order:
1. Starting a fresh Ethereum node
2. Deploying the DAO contracts
3. Sending ETH and enough API3 to your wallet.
4. Staking the API3
5. Running the `next-epoch` script
6. Navigating to the governance page

This can also be done by sending any transaction through the frontend, but the script should be fixed to do this automatically.

### Changes

1. Mine an empty block immediately after increasing the EVM time