### PR TITLE
Add .npmrc to fix intermittent script bug

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+scripts-prepend-node-path=true


### PR DESCRIPTION
### Description

I was getting an error when trying to run the new setup scripts locally. I'm guessing this is related to how I have Node.js setup locally. Found a fix here: https://stackoverflow.com/a/51295237 that resolved it for me.

### Changes

1. Add a `.npmrc` file with `scripts-prepend-node-path=true` 