### PR TITLE
running dashboard for mainnet in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# This Dockerfile builds a mainnet version for API3 DAO dashboard
+
+FROM node:lts-alpine as builder
+RUN apk add --no-cache git
+WORKDIR /usr/src/app
+ADD . .
+COPY src/contract-deployments/mainnet-dao.json ./src/contract-deployments/localhost-dao.example.json
+RUN yarn 
+RUN yarn tsc && yarn build
+
+FROM nginx:alpine
+EXPOSE 80
+COPY --from=builder /usr/src/app/build /usr/share/nginx/html
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ FROM node:lts-alpine as builder
 RUN apk add --no-cache git
 WORKDIR /usr/src/app
 ADD . .
-COPY src/contract-deployments/mainnet-dao.json ./src/contract-deployments/localhost-dao.example.json
 RUN yarn 
-RUN yarn tsc && yarn build
+RUN yarn build
 
 FROM nginx:alpine
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker build -t api3-dao-dashboard .
 docker run -d -p7770:80 --name api3-dao-dashboard api3-dao-dashboard
 ```
 
-This will create a API3 dashboard running on http://localhost:7770/ where it is safe to connect your wallet
+This will create a API3 dashboard running on port 7770 of your localhost where it is safe to connect your wallet.
 
 ## Instructions for testing on Rinkeby
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ The implementation of the DAO dashboard.
 
 [![ContinuousBuild](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml)
 
+## Running dashboard on Mainnet in docker container
+
+The decentralized approach of being a DAO member is to run API3 dashboard on your local machine. For that you will just need `git` and `docker`:
+```
+git clone --depth=1 git@github.com:api3dao/api3-dao-dashboard.git
+cd api3-dao-dashboard
+docker build -t api3-dao-dashboard .
+docker run -d -p7770:80 --name api3-dao-dashboard api3-dao-dashboard
+```
+
+This will create a API3 dashboard running on http://localhost:7770/ where it is safe to connect your wallet
+
 ## Instructions for testing on Rinkeby
 
 1. Install Metamask (https://metamask.io/download)


### PR DESCRIPTION
IPFS-hosted connectivity raises many complaints on dashboard functionality

The decentralized way of running dashboard from a local machine can be spread to address these issues.
