### PR TITLE
Fix HMR by pinning react-error-overlay to v6.0.9 (via a resolution)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-error.log*
 
 # IDEs
 .vscode
+.idea
 
 # DAO contract deployments - Will be regenerated after every localhost deploy.
 # We still want deployments to mainnet/testnet checked in git.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ latter command to remove the container, add the `--rm` flag to the above `docker
 2. `yarn eth:node` - to start hardhat network
 3. `yarn eth:prepare-dao-contracts-for-hardhat` - to download the DAO contract sources locally. You need to run this
    only when running for the first time.
-4. (Optional) Modify the pool contract `EPOCH_LENGTH` variable from `1 weeks` to `1 minute` to speed up testing. You can
-   find this constant inside `dao-contracts/packages/pool/contracts/StateUtils.sol`
+4. (Optional) Modify the pool contract `EPOCH_LENGTH` variable from `1 weeks` to `1 minutes` to speed up testing. You
+   can find this constant inside `dao-contracts/packages/pool/contracts/StateUtils.sol`
 5. `yarn eth:deploy-dao-contracts-on-hardhat` - to deploy the contracts locally
 6. Copy the `.env.example` to `.env`. Make sure that `REACT_APP_NODE_ENV` is set to `development`
 7. `yarn start` - to start the application on localhost on port 3000

--- a/package.json
+++ b/package.json
@@ -110,5 +110,9 @@
     "typechain": "^6.0.2",
     "typescript": "^4.5.5",
     "typescript-plugin-css-modules": "^3.4.0"
+  },
+  "resolutions": {
+    "//": "Remove once upgraded to react-scripts v5. See https://github.com/facebook/create-react-app/issues/11773",
+    "react-error-overlay": "6.0.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15549,10 +15549,10 @@ react-easy-swipe@^0.0.21:
   dependencies:
     prop-types "^15.5.8"
 
-react-error-overlay@^6.0.9:
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"
-  integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-fast-compare@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
I noticed that making any frontend code changes causes a runtime error in the HMR mechanism:
<img width="519" alt="Screenshot 2022-05-06 at 14 08 28" src="https://user-images.githubusercontent.com/747979/167128568-eca997e5-feb5-4b6d-aa14-6b054db771e9.png">
https://github.com/facebook/create-react-app/issues/11773

Turned out to be an issue with react-scripts v4 (in combo with its react-error-overlay dependency). Long term fix would be to upgrade to react-scripts v5, but for now pinning react-error-overlay to v6.0.9 fixes the problem.