### PR TITLE
DAO-152 Update Github actions cache keys (to force it to create new caches)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,14 +53,14 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: modules-${{ hashFiles('**/yarn.lock') }}
+          key: modules-v2-${{ hashFiles('**/yarn.lock') }}
       - name: Cache cypress
         id: cypress-cache
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-cypress-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-cypress-v2-${{ hashFiles('**/yarn.lock') }}
           path: ~/.cache/Cypress
-          restore-keys: ${{ runner.os }}-cypress-
+          restore-keys: ${{ runner.os }}-cypress-v2-
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Increase file watcher limit


### PR DESCRIPTION
Currently updating the keys is the only way to do it: 
https://github.community/t/how-to-clear-cache-in-github-actions/129038
https://stackoverflow.com/questions/63521430/clear-cache-in-github-actions