### PR TITLE
Add ClaimsManager deploy and seed scripts

### DIFF
--- a/dev-scripts/claims-manager/deploy-on-hardhat.js
+++ b/dev-scripts/claims-manager/deploy-on-hardhat.js
@@ -1,0 +1,37 @@
+const hre = require('hardhat');
+const { promiseWrapper } = require('../utils');
+
+async function deploy() {
+  const accounts = await hre.ethers.getSigners();
+  const roles = {
+    deployer: accounts[0],
+    manager: accounts[1],
+    kleros: accounts[2],
+  };
+  const accessControlRegistryFactory = await hre.ethers.getContractFactory('AccessControlRegistry', roles.deployer);
+  const accessControlRegistry = await accessControlRegistryFactory.deploy();
+  const mockApi3PoolFactory = await hre.ethers.getContractFactory('MockApi3Pool', roles.deployer);
+  const mockApi3Pool = await mockApi3PoolFactory.deploy();
+
+  const claimsManagerWithKlerosArbitratorFactory = await hre.ethers.getContractFactory(
+    'ClaimsManagerWithKlerosArbitrator',
+    roles.deployer
+  );
+  const claimsManager = await claimsManagerWithKlerosArbitratorFactory.deploy(
+    accessControlRegistry.address,
+    'ClaimsManager admin',
+    roles.manager.address,
+    mockApi3Pool.address,
+    3 * 24 * 60 * 60,
+    3 * 24 * 60 * 60,
+    roles.kleros.address,
+    '0x123456',
+    40 * 24 * 60 * 60,
+    '/ipfs/Qm...testhash/metaevidence.json'
+  );
+
+  console.info('DEPLOYED ADDRESSES:');
+  console.info(JSON.stringify({ claimsManager: claimsManager.address }, null, 2));
+}
+
+promiseWrapper(deploy);

--- a/dev-scripts/claims-manager/deploy-on-hardhat.js
+++ b/dev-scripts/claims-manager/deploy-on-hardhat.js
@@ -27,7 +27,7 @@ async function deploy() {
     roles.kleros.address,
     '0x123456',
     40 * 24 * 60 * 60,
-    '/ipfs/Qm...testhash/metaevidence.json'
+    '/ipfs/Qm...testhash/metaEvidence.json'
   );
 
   console.info('DEPLOYED ADDRESSES:');

--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -72,18 +72,16 @@ task('create-user-policy', 'Creates a policy for the given user')
     // The index for the manager needs to be in sync with the deploy script
     const manager = accounts[1];
     const claimsManager = ClaimsManagerFactory.connect(process.env.REACT_APP_CLAIMS_MANAGER_ADDRESS, manager);
-    const transactions = await Promise.all([
-      await claimsManager.createPolicy(
-        userAddress,
-        userAddress,
-        parseApi3(args.coverageAmount),
-        BigNumber.from(Math.round(addDays(new Date(), -1).getTime() / 1000)),
-        BigNumber.from(Math.round(addDays(new Date(), 30).getTime() / 1000)),
-        args.ipfsHash
-      ),
-    ]);
+    const tx = await claimsManager.createPolicy(
+      userAddress,
+      userAddress,
+      parseApi3(args.coverageAmount),
+      BigNumber.from(Math.round(addDays(new Date(), -1).getTime() / 1000)),
+      BigNumber.from(Math.round(addDays(new Date(), 30).getTime() / 1000)),
+      args.ipfsHash
+    );
 
-    await Promise.all(transactions.map((tx) => tx.wait()));
+    await tx.wait();
     const createdEvents = await claimsManager.queryFilter(claimsManager.filters.CreatedPolicy(null, userAddress));
 
     console.info(`User policies (${createdEvents.length}):`);

--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -2,6 +2,10 @@ import '@nomiclabs/hardhat-ethers';
 import { task, HardhatUserConfig } from 'hardhat/config';
 import { existsSync } from 'fs';
 import dotenv from 'dotenv';
+import { BigNumber } from 'ethers';
+import { addDays } from 'date-fns';
+import { parseApi3 } from '../src/utils/api3-format';
+const { ClaimsManagerWithKlerosArbitrator__factory: ClaimsManagerFactory } = require('../src/contracts/tmp');
 
 dotenv.config({ path: '../.env' });
 
@@ -55,6 +59,37 @@ task('send-to-account', 'Sends ether or API3 tokens to a specified account')
     console.info(`Sent ${hre.ethers.utils.formatEther(tokens)} API3 tokens to address ${receiver}`);
     await deployer.sendTransaction({ to: receiver, value: ether });
     console.info(`Sent ${hre.ethers.utils.formatEther(ether)} ETH to address ${receiver}`);
+  });
+
+task('create-user-policy', 'Creates a policy for the given user')
+  .addParam('address', 'The user address')
+  .addParam('coverageAmount', 'The coverage amount')
+  .addParam('ipfsHash', 'The IPFS policy hash')
+  .setAction(async (args, hre) => {
+    const userAddress = args.address;
+    const accounts = await hre.ethers.getSigners();
+
+    // The index for the manager needs to be in sync with the deploy script
+    const manager = accounts[1];
+    const claimsManager = ClaimsManagerFactory.connect(process.env.REACT_APP_CLAIMS_MANAGER_ADDRESS, manager);
+    const transactions = await Promise.all([
+      await claimsManager.createPolicy(
+        userAddress,
+        userAddress,
+        parseApi3(args.coverageAmount),
+        BigNumber.from(Math.round(addDays(new Date(), -1).getTime() / 1000)),
+        BigNumber.from(Math.round(addDays(new Date(), 30).getTime() / 1000)),
+        args.ipfsHash
+      ),
+    ]);
+
+    await Promise.all(transactions.map((tx) => tx.wait()));
+    const createdEvents = await claimsManager.queryFilter(claimsManager.filters.CreatedPolicy(null, userAddress));
+
+    console.info(`User policies (${createdEvents.length}):`);
+    createdEvents.forEach((event: any) => {
+      console.info(event.args.policyHash);
+    });
   });
 
 // See https://hardhat.org/config/

--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 import { BigNumber } from 'ethers';
 import { addDays } from 'date-fns';
 import { parseApi3 } from '../src/utils/api3-format';
-const { ClaimsManagerWithKlerosArbitrator__factory: ClaimsManagerFactory } = require('../src/contracts/tmp');
+import { ClaimsManagerWithKlerosArbitrator__factory as ClaimsManagerFactory } from '../src/contracts/tmp';
 
 dotenv.config({ path: '../.env' });
 
@@ -71,7 +71,7 @@ task('create-user-policy', 'Creates a policy for the given user')
 
     // The index for the manager needs to be in sync with the deploy script
     const manager = accounts[1];
-    const claimsManager = ClaimsManagerFactory.connect(process.env.REACT_APP_CLAIMS_MANAGER_ADDRESS, manager);
+    const claimsManager = ClaimsManagerFactory.connect(process.env.REACT_APP_CLAIMS_MANAGER_ADDRESS!, manager);
     const tx = await claimsManager.createPolicy(
       userAddress,
       userAddress,
@@ -85,7 +85,7 @@ task('create-user-policy', 'Creates a policy for the given user')
     const createdEvents = await claimsManager.queryFilter(claimsManager.filters.CreatedPolicy(null, userAddress));
 
     console.info(`User policies (${createdEvents.length}):`);
-    createdEvents.forEach((event: any) => {
+    createdEvents.forEach((event) => {
       console.info(event.args.policyHash);
     });
   });


### PR DESCRIPTION
At this stage it's still quite a process to test locally, but the current steps are:
1. Clone https://github.com/api3dao/claims-manager
2. cd into claims-manager repo and run:
 `yarn && yarn build`
3. (still in the claims-manger repo) :
`npx hardhat run ../api3-dao-dashboard/dev-scripts/claims-manager/deploy-on-hardhat.js  --network localhost`
4. In api3-doa-dashboard repo, set REACT_APP_CLAIMS_MANAGER_ADDRESS in .env (address gets printed out in previous step)
4. cd into the api3-dao-dashboard/hardhat folder and create yourself a policy:
`npx hardhat create-user-policy --address YOUR_ADDRESS --coverage-amount 500 --ipfs-hash some-hash-001`
5. Start your dev server and use the policy hash printed out in previous step to navigate to:
http://localhost:3000/#/policies/POLICY_HASH

From there you can create a claim (still work in progress), and afterwards go to http://localhost:3000/#/claims to see your claims