### PR TITLE
DAO-166 Button component improvements

### DIFF
--- a/src/components/button/button.module.scss
+++ b/src/components/button/button.module.scss
@@ -1,8 +1,15 @@
 @import '../../styles/variables.module.scss';
 
-.buttonWrapper {
-  display: inline-block;
-  &.disabled {
+.button {
+  background-color: transparent;
+  position: relative;
+  color: $button-color;
+  border-width: 1px;
+  border-style: solid;
+  outline: none;
+  cursor: pointer;
+
+  &:disabled {
     opacity: 0.4;
     pointer-events: none;
   }
@@ -12,69 +19,67 @@
   }
 }
 
-.button {
-  background-color: transparent;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: $button-color;
-  border-width: 1px;
-  border-style: solid;
-  outline: none;
-  cursor: pointer;
+.primary {
+  border-image-source: $primary-border;
+  border-image-slice: 1;
 
-  &.primary {
-    border-image-source: $primary-border;
-    border-image-slice: 1;
-  }
-
-  &.secondary {
-    border-color: $secondary-border;
-  }
-
-  &.normal {
-    font-size: $text-small;
-    line-height: $lh-small;
-    padding: 17px $space-lg;
-
-    @media (max-width: $max-md) {
-      padding: $space-md;
-    }
-  }
-
-  &.large {
-    font-size: $text-normal;
-    line-height: 22px;
-    padding: 20px 44px;
-
-    @media (max-width: $max-md) {
-      font-size: $text-small;
-      padding: $space-md $space-xl;
-    }
-  }
-
-  &.link {
-    color: $link-color;
-    border: 0;
-    text-decoration: underline;
-    padding: 0;
-  }
-
-  &.text {
-    border: 0;
-    text-decoration: underline;
-    padding: 0;
+  &::after {
+    background: $primary-border;
   }
 }
 
-.buttonUnderline {
-  margin-top: $space-xxs;
-  height: 1px;
-  width: 100%;
-  &.primary {
-    background: linear-gradient(to left, $green-color, $violet-color);
-  }
-  &.secondary {
+.secondary {
+  border-color: $secondary-border;
+
+  &::after {
     background-color: $secondary-border;
   }
+}
+
+.primary,
+.secondary {
+  margin-bottom: 5px;
+
+  &::after {
+    content: '';
+    height: 1px;
+    width: calc(100% + 2px);
+    position: absolute;
+    bottom: -6px;
+    left: -1px;
+  }
+}
+
+.normal {
+  font-size: $text-small;
+  line-height: $lh-small;
+  padding: 17px $space-lg;
+
+  @media (max-width: $max-md) {
+    padding: $space-md;
+  }
+}
+
+.large {
+  font-size: $text-normal;
+  line-height: 22px;
+  padding: 20px 44px;
+
+  @media (max-width: $max-md) {
+    font-size: $text-small;
+    padding: $space-md $space-xl;
+  }
+}
+
+.link {
+  color: $link-color;
+  border: 0;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.text {
+  border: 0;
+  text-decoration: underline;
+  padding: 0;
 }

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,17 +1,15 @@
-import { ReactNode } from 'react';
+import { ComponentProps } from 'react';
 import classNames from 'classnames';
 import styles from './button.module.scss';
 
-type Props = {
-  children: ReactNode;
-  className?: string;
+interface Props extends ComponentProps<'button'> {
   variant?: 'primary' | 'secondary' | 'link' | 'text';
   size?: 'normal' | 'large';
-  disabled?: boolean;
-  onClick?: () => void;
-};
+}
 
-const Button = ({ children, disabled, variant = 'primary', size = 'normal', onClick, className }: Props) => {
+export default function Button(props: Props) {
+  const { className, children, variant = 'primary', size = 'normal', ...rest } = props;
+
   return (
     <button
       className={classNames(styles.button, className, {
@@ -22,12 +20,9 @@ const Button = ({ children, disabled, variant = 'primary', size = 'normal', onCl
         [styles.normal]: size === 'normal' && variant !== 'link',
         [styles.large]: size === 'large' && variant !== 'link',
       })}
-      onClick={onClick}
-      disabled={disabled}
+      {...rest}
     >
       {children}
     </button>
   );
-};
-
-export default Button;
+}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -5,22 +5,22 @@ import styles from './button.module.scss';
 type Props = {
   children: ReactNode;
   className?: string;
-  type?: 'primary' | 'secondary' | 'link' | 'text';
+  variant?: 'primary' | 'secondary' | 'link' | 'text';
   size?: 'normal' | 'large';
   disabled?: boolean;
   onClick?: () => void;
 };
 
-const Button = ({ children, disabled, type = 'primary', size = 'normal', onClick, className }: Props) => {
+const Button = ({ children, disabled, variant = 'primary', size = 'normal', onClick, className }: Props) => {
   return (
     <button
       className={classNames(styles.button, className, {
-        [styles.primary]: type === 'primary',
-        [styles.secondary]: type === 'secondary',
-        [styles.link]: type === 'link',
-        [styles.text]: type === 'text',
-        [styles.normal]: size === 'normal' && type !== 'link',
-        [styles.large]: size === 'large' && type !== 'link',
+        [styles.primary]: variant === 'primary',
+        [styles.secondary]: variant === 'secondary',
+        [styles.link]: variant === 'link',
+        [styles.text]: variant === 'text',
+        [styles.normal]: size === 'normal' && variant !== 'link',
+        [styles.large]: size === 'large' && variant !== 'link',
       })}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -13,30 +13,20 @@ type Props = {
 
 const Button = ({ children, disabled, type = 'primary', size = 'normal', onClick, className }: Props) => {
   return (
-    <div className={classNames(styles.buttonWrapper, { [styles.disabled]: disabled }, className)}>
-      <button
-        className={classNames(styles.button, {
-          [styles.primary]: type === 'primary',
-          [styles.secondary]: type === 'secondary',
-          [styles.link]: type === 'link',
-          [styles.text]: type === 'text',
-          [styles.normal]: size === 'normal' && type !== 'link',
-          [styles.large]: size === 'large' && type !== 'link',
-        })}
-        onClick={onClick}
-        disabled={disabled}
-      >
-        {children}
-      </button>
-      {['primary', 'secondary'].includes(type) && (
-        <div
-          className={classNames(styles.buttonUnderline, {
-            [styles.primary]: type === 'primary',
-            [styles.secondary]: type === 'secondary',
-          })}
-        />
-      )}
-    </div>
+    <button
+      className={classNames(styles.button, className, {
+        [styles.primary]: type === 'primary',
+        [styles.secondary]: type === 'secondary',
+        [styles.link]: type === 'link',
+        [styles.text]: type === 'text',
+        [styles.normal]: size === 'normal' && type !== 'link',
+        [styles.large]: size === 'large' && type !== 'link',
+      })}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </button>
   );
 };
 

--- a/src/components/layout/error-reporting-notice/error-reporting-notice.tsx
+++ b/src/components/layout/error-reporting-notice/error-reporting-notice.tsx
@@ -46,7 +46,7 @@ const ErrorReportingNotice = (props: WelcomeModalContentProps) => {
             />
             <label htmlFor="errorReporting">Allow error reporting</label>
           </div>
-          <Button type="secondary" onClick={onErrorReportingNoticeConfirm}>
+          <Button variant="secondary" onClick={onErrorReportingNoticeConfirm}>
             Done
           </Button>
         </div>

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -78,9 +78,7 @@
 }
 
 .externalLinkButton {
-  button {
-    color: $secondary-color;
-  }
+  color: $secondary-color;
 }
 
 .linkSeparator {
@@ -90,11 +88,7 @@
 }
 
 .noUnderline {
-  text-decoration: none;
-
-  button {
-    text-decoration: none !important;
-  }
+  text-decoration: none !important;
 }
 
 .linkSpacing {

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -72,7 +72,7 @@ export const BaseLayout = ({ children, subtitle }: BaseLayoutProps) => {
                       return (
                         <Button
                           key={link.text}
-                          type="text"
+                          variant="text"
                           className={classNames(styles.externalLinkButton, styles.noUnderline)}
                           onClick={link.onClick}
                         >

--- a/src/components/sign-in/sign-in.module.scss
+++ b/src/components/sign-in/sign-in.module.scss
@@ -15,10 +15,7 @@
 
 .mobileMenuButton {
   width: 100%;
-  button {
-    width: 100%;
-    color: $secondary-black-color;
-  }
+  color: $secondary-black-color;
 }
 
 .mobileMenuConnectedStatus {
@@ -45,9 +42,6 @@
 .fullWidthMobile {
   @media (max-width: $max-sm) {
     width: 100%;
-    button {
-      width: 100%;
-    }
   }
 }
 
@@ -56,9 +50,7 @@
 }
 
 .availableAccountButton {
-  button {
-    height: unset !important;
-  }
+  height: unset !important;
 }
 
 .availableAccounts {

--- a/src/components/sign-in/sign-in.tsx
+++ b/src/components/sign-in/sign-in.tsx
@@ -70,7 +70,7 @@ const ConnectedStatus = ({ dark, position }: Props) => {
           {connectedContent}
           {availableAccounts.length > 1 && (
             <Button
-              type="secondary"
+              variant="secondary"
               onClick={openModal}
               className={classNames({ [styles.mobileMenuButton]: position === 'mobileMenu' })}
             >
@@ -78,7 +78,7 @@ const ConnectedStatus = ({ dark, position }: Props) => {
             </Button>
           )}
           <Button
-            type="secondary"
+            variant="secondary"
             onClick={onDisconnect}
             className={classNames({ [styles.mobileMenuButton]: position === 'mobileMenu' })}
           >
@@ -106,7 +106,7 @@ const ConnectedStatus = ({ dark, position }: Props) => {
             {availableAccounts.map((account) => (
               <Button
                 key={account}
-                type="text"
+                variant="text"
                 className={styles.availableAccountButton}
                 onClick={onAccountChange(account)}
               >
@@ -182,7 +182,7 @@ const SignIn = ({ dark, position }: Props) => {
     <>
       {!provider && (
         <Button
-          type={dark ? 'secondary' : 'primary'}
+          variant={dark ? 'secondary' : 'primary'}
           onClick={connectWallet(setChainData)}
           className={classNames({
             [styles.mobileMenuButton]: dark,

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -80,7 +80,7 @@ export default function ClaimActions(props: Props) {
             </div>
             <div className={styles.actionPanel}>
               <Button
-                type="secondary"
+                variant="secondary"
                 disabled={isPastNewDeadline || status === 'submitting' || status === 'submitted'}
                 onClick={handleEscalateToArbitrator}
               >
@@ -123,10 +123,10 @@ export default function ClaimActions(props: Props) {
             {formatApi3(claim.counterOfferAmount!)} API3
           </div>
           <div className={styles.actionPanel}>
-            <Button type="primary" disabled={disableActions} onClick={handleAcceptCounter}>
+            <Button variant="primary" disabled={disableActions} onClick={handleAcceptCounter}>
               Accept Counter
             </Button>
-            <Button type="secondary" disabled={disableActions} onClick={handleEscalateToArbitrator}>
+            <Button variant="secondary" disabled={disableActions} onClick={handleEscalateToArbitrator}>
               Escalate to Kleros
             </Button>
           </div>
@@ -210,7 +210,7 @@ export default function ClaimActions(props: Props) {
             {formatApi3(claim.counterOfferAmount!)} API3
           </div>
           <div className={styles.actionPanel}>
-            <Button type="secondary" disabled={disableActions} onClick={handleAppeal}>
+            <Button variant="secondary" disabled={disableActions} onClick={handleAppeal}>
               Appeal
             </Button>
           </div>
@@ -226,7 +226,7 @@ export default function ClaimActions(props: Props) {
           <p>Kleros</p>
           <div className={styles.actionMainInfo}>Rejected</div>
           <div className={styles.actionPanel}>
-            <Button type="secondary" disabled={disableActions} onClick={handleAppeal}>
+            <Button variant="secondary" disabled={disableActions} onClick={handleAppeal}>
               Appeal
             </Button>
           </div>

--- a/src/pages/claims/claims.tsx
+++ b/src/pages/claims/claims.tsx
@@ -36,7 +36,7 @@ export default function Claims() {
       <ClaimsLayout>
         <div className={styles.emptyState}>
           <span>You need to be connected to view claims.</span>
-          <Button type="link" onClick={connectWallet(setChainData)}>
+          <Button variant="link" onClick={connectWallet(setChainData)}>
             Connect your wallet
           </Button>
         </div>

--- a/src/pages/dashboard/dashboard.tsx
+++ b/src/pages/dashboard/dashboard.tsx
@@ -89,7 +89,7 @@ const Dashboard = () => {
               </>
             }
             footer={
-              <Button type="link" onClick={() => setOpenModal('withdraw')} disabled={!canWithdraw}>
+              <Button variant="link" onClick={() => setOpenModal('withdraw')} disabled={!canWithdraw}>
                 Withdraw
               </Button>
             }
@@ -128,7 +128,7 @@ const Dashboard = () => {
             }
             footer={
               // TODO: In case there is a pending unstake there should be no button, just green arrow (see figma)
-              <Button type="link" onClick={() => setOpenModal('unstake')} disabled={!canInitiateUnstake}>
+              <Button variant="link" onClick={() => setOpenModal('unstake')} disabled={!canInitiateUnstake}>
                 Initiate Unstake
               </Button>
             }

--- a/src/pages/dashboard/forms/confirm-unstake-form.tsx
+++ b/src/pages/dashboard/forms/confirm-unstake-form.tsx
@@ -24,10 +24,10 @@ const ConfirmUnstakeForm = (props: Props) => {
 
       <ModalFooter>
         <div className={styles.tokenAmountFormActions}>
-          <Button type="text" onClick={onClose} className={styles.cancelButton}>
+          <Button variant="text" onClick={onClose} className={styles.cancelButton}>
             Cancel
           </Button>
-          <Button type="secondary" onClick={handleAction}>
+          <Button variant="secondary" onClick={handleAction}>
             Initiate Unstaking
           </Button>
         </div>

--- a/src/pages/dashboard/forms/forms.module.scss
+++ b/src/pages/dashboard/forms/forms.module.scss
@@ -39,9 +39,7 @@
 }
 
 .maxButton {
-  button {
-    margin: 0 0 0 $space-sm;
-  }
+  margin: 0 0 0 $space-sm;
 }
 
 .cancelButton {

--- a/src/pages/dashboard/forms/token-amount-form.tsx
+++ b/src/pages/dashboard/forms/token-amount-form.tsx
@@ -62,7 +62,7 @@ const TokenAmountForm = (props: Props) => {
             autoFocus
           />
           {maxValue && (
-            <Button className={styles.maxButton} type="text" onClick={handleSetMax}>
+            <Button className={styles.maxButton} variant="text" onClick={handleSetMax}>
               Max
             </Button>
           )}
@@ -81,7 +81,7 @@ const TokenAmountForm = (props: Props) => {
 
       <ModalFooter>
         <div className={styles.tokenAmountFormActions}>
-          <Button type="secondary" onClick={handleAction} disabled={!goParseApi3.success}>
+          <Button variant="secondary" onClick={handleAction} disabled={!goParseApi3.success}>
             {action}
           </Button>
         </div>

--- a/src/pages/dashboard/forms/token-deposit-form.tsx
+++ b/src/pages/dashboard/forms/token-deposit-form.tsx
@@ -103,7 +103,7 @@ const TokenDepositForm = (props: Props) => {
             size="large"
             autoFocus
           />
-          <Button className={styles.maxButton} type="text" onClick={handleSetMax} size="normal">
+          <Button className={styles.maxButton} variant="text" onClick={handleSetMax} size="normal">
             Max
           </Button>
         </div>
@@ -119,12 +119,12 @@ const TokenDepositForm = (props: Props) => {
       <ModalFooter>
         <div className={styles.tokenAmountFormActions}>
           {approvalRequired ? (
-            <Button type="secondary" onClick={handleApprove} className={styles.tokenAmountFormApprove}>
+            <Button variant="secondary" onClick={handleApprove} className={styles.tokenAmountFormApprove}>
               Approve
             </Button>
           ) : (
             <Button
-              type="link"
+              variant="link"
               className={styles.tokenAmountFormApprove}
               onClick={handleDeposit('deposit-only')}
               disabled={!canDeposit}
@@ -133,7 +133,7 @@ const TokenDepositForm = (props: Props) => {
             </Button>
           )}
 
-          <Button type="secondary" onClick={handleDeposit('deposit-and-stake')} disabled={!canDeposit}>
+          <Button variant="secondary" onClick={handleDeposit('deposit-and-stake')} disabled={!canDeposit}>
             Deposit and Stake
           </Button>
         </div>

--- a/src/pages/dashboard/pending-unstake-panel/pending-unstake-panel.tsx
+++ b/src/pages/dashboard/pending-unstake-panel/pending-unstake-panel.tsx
@@ -114,7 +114,7 @@ const PendingUnstakePanel = (props: Props) => {
             </div>
           </div>
           <div className={styles.pendingUnstakeActions}>
-            <Button type="link" onClick={handleUnstake} disabled={!canUnstake}>
+            <Button variant="link" onClick={handleUnstake} disabled={!canUnstake}>
               Unstake
             </Button>
             <Button onClick={handleUnstakeAndWithdraw} disabled={!canUnstakeAndWithdraw}>

--- a/src/pages/dashboard/unstake-banner/unstake-banner.tsx
+++ b/src/pages/dashboard/unstake-banner/unstake-banner.tsx
@@ -42,7 +42,7 @@ const UnstakeBanner = (props: Props) => {
         </div>
       </div>
       <div className={styles.buttonPanel}>
-        <Button type="link" onClick={handleUnstake}>
+        <Button variant="link" onClick={handleUnstake}>
           Unstake
         </Button>
         <Button onClick={handleUnstakeAndWithdraw} disabled={!canUnstakeAndWithdraw}>

--- a/src/pages/policies/policies.tsx
+++ b/src/pages/policies/policies.tsx
@@ -48,7 +48,7 @@ export default function Policies() {
       <PoliciesLayout>
         <div className={styles.emptyState}>
           You need to be connected to view your policies.
-          <Button type="link" onClick={connectWallet(setChainData)} className={styles.connectButton}>
+          <Button variant="link" onClick={connectWallet(setChainData)} className={styles.connectButton}>
             Connect your wallet
           </Button>
         </div>

--- a/src/pages/policies/policy-list.tsx
+++ b/src/pages/policies/policy-list.tsx
@@ -44,7 +44,7 @@ export default function PolicyList(props: Props) {
 
           <div className={styles.policyItemAction}>
             {canCreateClaim(policy) ? (
-              <Button type="secondary" onClick={() => history.push(`/policies/${policy.policyId}/claims/new`)}>
+              <Button variant="secondary" onClick={() => history.push(`/policies/${policy.policyId}/claims/new`)}>
                 Create a Claim
               </Button>
             ) : (
@@ -56,7 +56,7 @@ export default function PolicyList(props: Props) {
                 }
               >
                 <div>
-                  <Button type="secondary" disabled>
+                  <Button variant="secondary" disabled>
                     Create a Claim
                   </Button>
                 </div>

--- a/src/pages/proposal-commons/proposal-details/proposal-details.module.scss
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.module.scss
@@ -1,10 +1,12 @@
 @import '../../../styles/variables.module.scss';
 
-.backBtn {
-  button {
-    color: $secondary-color;
-    text-decoration: none !important;
-  }
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  color: $secondary-color;
+  text-decoration: none;
+  font-size: $text-small;
+  line-height: $lh-small;
 }
 
 .proposalDetailsSubheader {

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -134,11 +134,9 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
   return (
     <div>
       <div className={styles.proposalDetailsSubheader}>
-        <Link to={backButton.url} data-cy="api3-logo">
-          <Button type="text" className={styles.backBtn}>
-            <img src={images.arrowLeft} alt="back" />
-            {backButton.text}
-          </Button>
+        <Link to={backButton.url} className={styles.backLink}>
+          <img src={images.arrowLeft} alt="back" />
+          {backButton.text}
         </Link>
       </div>
 

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -161,7 +161,7 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
         <VoteSlider {...voteSliderData} size="large" />
         <VoteStatus voterState={voteSliderData.voterState} wasDelegated={voteSliderData.wasDelegated} large />
         <div>
-          <Button type="secondary" size="large" onClick={() => setVoteModalOpen(true)} disabled={!canVote}>
+          <Button variant="secondary" size="large" onClick={() => setVoteModalOpen(true)} disabled={!canVote}>
             Vote
           </Button>
           <TooltipChecklist items={canVoteChecklist}>

--- a/src/pages/proposal-commons/proposal-details/vote-form/vote-form.tsx
+++ b/src/pages/proposal-commons/proposal-details/vote-form/vote-form.tsx
@@ -30,7 +30,7 @@ const VoteForm = (props: Props) => {
           />
         </div>
       </div>
-      <Button type="secondary" size="large" onClick={() => onConfirm(checked)}>
+      <Button variant="secondary" size="large" onClick={() => onConfirm(checked)}>
         Create Transaction
       </Button>
     </div>

--- a/src/pages/proposal-commons/proposal-list/proposal-list.tsx
+++ b/src/pages/proposal-commons/proposal-list/proposal-list.tsx
@@ -69,7 +69,7 @@ const ProposalList = (props: Props) => {
     return (
       <div className={styles.noProposals}>
         <span>You need to be connected to view proposals</span>
-        <Button type="link" onClick={connectWallet(setChainData)}>
+        <Button variant="link" onClick={connectWallet(setChainData)}>
           Connect your wallet
         </Button>
       </div>

--- a/src/pages/proposal-commons/proposal-list/proposal-status/proposal-status.module.scss
+++ b/src/pages/proposal-commons/proposal-list/proposal-status/proposal-status.module.scss
@@ -32,14 +32,8 @@
 }
 
 .execute {
-  .button {
-    padding: 0;
-  }
-
-  button {
-    font-size: 18px;
-    line-height: 28px;
-  }
+  font-size: 18px;
+  line-height: 28px;
 }
 
 .flex {

--- a/src/pages/proposal-commons/proposal-list/proposal-status/proposal-status.tsx
+++ b/src/pages/proposal-commons/proposal-list/proposal-status/proposal-status.tsx
@@ -44,7 +44,7 @@ const ProposalStatus = (props: Props) => {
       )}
       {proposalStatus === 'Execute' ? (
         <Button
-          type="text"
+          variant="text"
           className={styles.execute}
           onClick={async () => {
             if (!voting) return;

--- a/src/pages/proposals/delegation/delegation.module.scss
+++ b/src/pages/proposals/delegation/delegation.module.scss
@@ -1,7 +1,0 @@
-@import '../../../styles//variables.module.scss';
-
-.proposalsLink {
-  button._normal {
-    padding: 0;
-  }
-}

--- a/src/pages/proposals/delegation/delegation.tsx
+++ b/src/pages/proposals/delegation/delegation.tsx
@@ -12,7 +12,6 @@ import { handleTransactionError } from '../../../utils';
 import { images } from '../../../utils';
 import { useLoadDashboardData } from '../../../logic/dashboard';
 import { TooltipChecklist } from '../../../components/tooltip';
-import styles from './delegation.module.scss';
 import classNames from 'classnames';
 
 const Delegation = () => {
@@ -51,7 +50,6 @@ const Delegation = () => {
             Delegated to: {delegation.delegateName ? delegation.delegateName : abbrStr(delegation.delegate)}
           </p>
           <Button
-            className={styles.proposalsLink}
             type="text"
             onClick={() => setOpenChooseDelegateActionModal(true)}
             disabled={!canDelegate && !canUndelegate}
@@ -87,12 +85,7 @@ const Delegation = () => {
       ) : (
         <div>
           <p className={classNames(globalStyles.secondaryColor, globalStyles.bold)}>Undelegated</p>
-          <Button
-            className={styles.proposalsLink}
-            type="text"
-            onClick={() => setOpenDelegationModal(true)}
-            disabled={!canDelegate}
-          >
+          <Button type="text" onClick={() => setOpenDelegationModal(true)} disabled={!canDelegate}>
             Delegate
           </Button>
           <TooltipChecklist items={delegateChecklistItems}>

--- a/src/pages/proposals/delegation/delegation.tsx
+++ b/src/pages/proposals/delegation/delegation.tsx
@@ -50,7 +50,7 @@ const Delegation = () => {
             Delegated to: {delegation.delegateName ? delegation.delegateName : abbrStr(delegation.delegate)}
           </p>
           <Button
-            type="text"
+            variant="text"
             onClick={() => setOpenChooseDelegateActionModal(true)}
             disabled={!canDelegate && !canUndelegate}
           >
@@ -85,7 +85,7 @@ const Delegation = () => {
       ) : (
         <div>
           <p className={classNames(globalStyles.secondaryColor, globalStyles.bold)}>Undelegated</p>
-          <Button type="text" onClick={() => setOpenDelegationModal(true)} disabled={!canDelegate}>
+          <Button variant="text" onClick={() => setOpenDelegationModal(true)} disabled={!canDelegate}>
             Delegate
           </Button>
           <TooltipChecklist items={delegateChecklistItems}>

--- a/src/pages/proposals/forms/choose-delegate-action/choose-delegate-action.tsx
+++ b/src/pages/proposals/forms/choose-delegate-action/choose-delegate-action.tsx
@@ -18,11 +18,11 @@ const ChooseDelegateAction = (props: Props) => {
 
       <ModalFooter>
         <div className={styles.actions}>
-          <Button type="secondary" onClick={onUpdateDelegation} disabled={!canUpdateDelegation}>
+          <Button variant="secondary" onClick={onUpdateDelegation} disabled={!canUpdateDelegation}>
             Update delegation
           </Button>
 
-          <Button type="secondary" onClick={onUndelegate} disabled={!canUndelegate}>
+          <Button variant="secondary" onClick={onUndelegate} disabled={!canUndelegate}>
             Undelegate
           </Button>
         </div>

--- a/src/pages/proposals/forms/delegate/delegate-form.tsx
+++ b/src/pages/proposals/forms/delegate/delegate-form.tsx
@@ -86,7 +86,7 @@ const DelegateVotesForm = (props: Props) => {
       </div>
 
       <ModalFooter>
-        <Button type="secondary" size="large" onClick={onDelegate}>
+        <Button variant="secondary" size="large" onClick={onDelegate}>
           Delegate
         </Button>
 

--- a/src/pages/proposals/forms/new-proposal-form.tsx
+++ b/src/pages/proposals/forms/new-proposal-form.tsx
@@ -176,7 +176,7 @@ const NewProposalForm = (props: Props) => {
 
       <ModalFooter>
         <Button
-          type="secondary"
+          variant="secondary"
           size="large"
           onClick={async () => {
             const formData = {


### PR DESCRIPTION
### What does this change?
- Uses a pure CSS solution for the Button underline
- Removes the wrapping div
- Renames the `type` prop to `variant` (type clashes with the HTML button type prop)
- Updates props to accept any HTML button prop

### How did you action this task?
I used an absolutely positioned pseudo `::after` element to create the underline. In order to have no visual impact, a `margin-bottom` was added as well to the button to cater for the underline's space.

I went through all the Button usages where a `className` was used, and adjusted the CSS to no longer target a nested `button` element.