### PR TITLE
DAO-173 Add additional cypress install to "Install Dependencies" step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,10 @@ jobs:
           path: ~/.cache/Cypress
           restore-keys: ${{ runner.os }}-cypress-v2-
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        # We add the additional cypress install to handle the common Missing Binary issue: https://docs.cypress.io/guides/continuous-integration/introduction#Missing-binary
+        run: |
+          yarn install --frozen-lockfile
+          yarn cypress install
       - name: Increase file watcher limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Prepare DAO contracts

--- a/src/components/timer/timer.tsx
+++ b/src/components/timer/timer.tsx
@@ -99,7 +99,7 @@ const Timer = (props: Props) => {
           </>
         )}
       </div>
-      {showDeadline && <div className={globalStyles.tertiaryColor}>{formattedDeadline}</div>}
+      {showDeadline && <div className={`visual-test:invisible ${globalStyles.tertiaryColor}`}>{formattedDeadline}</div>}
     </div>
   );
 };


### PR DESCRIPTION
### What does this change?
It fixes the missing binary issue: https://docs.cypress.io/guides/continuous-integration/introduction#Missing-binary
The issue occurred on a couple of builds today: https://github.com/api3dao/api3-dao-dashboard/runs/7354402845?check_suite_focus=true

### How did you action this task?
The cypress binary gets installed via a `postinstall` hook that sometimes doesn't trigger, so the additional `yarn cypress install` command installs the binary only if it is not present (otherwise it skips)