### PR TITLE
DAO-183 Fix policy and claim details loading (with new useChainUpdateEffect() hook)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,12 @@
   "extends": ["react-app", "react-app/jest"],
   "rules": {
     "prefer-const": "error",
-    "no-console": ["error", { "allow": ["group", "groupEnd"] }]
+    "no-console": ["error", { "allow": ["group", "groupEnd"] }],
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "(useChainUpdateEffect)"
+      }
+    ]
   }
 }

--- a/src/contracts/hooks.ts
+++ b/src/contracts/hooks.ts
@@ -183,6 +183,11 @@ export const usePossibleChainDataUpdate = (
   });
 };
 
+/**
+ * A hook that behaves like the useEffect hook, except that it also triggers the effect
+ *  1) after a new block is mined
+ *  2) when the network or account changes
+ */
 export function useChainUpdateEffect(effectFn: () => void | (() => void), effectDeps: any[]) {
   const { provider, networkName, userAccount } = useChainData();
 

--- a/src/logic/policies/data.ts
+++ b/src/logic/policies/data.ts
@@ -3,7 +3,12 @@ import { isWithinInterval } from 'date-fns';
 import { go } from '@api3/promise-utils';
 import { blockTimestampToDate, messages } from '../../utils';
 import { Policy, updateImmutablyCurried, useChainData } from '../../chain-data';
-import { ClaimsManagerWithKlerosArbitration, useClaimsManager, usePossibleChainDataUpdate } from '../../contracts';
+import {
+  ClaimsManagerWithKlerosArbitration,
+  useClaimsManager,
+  usePossibleChainDataUpdate,
+  useChainUpdateEffect,
+} from '../../contracts';
 import { notifications } from '../../components/notifications';
 
 export function useUserPolicies() {
@@ -54,28 +59,30 @@ export function useUserPolicyById(policyId: string) {
   const data = policies.byId?.[policyId] || null;
 
   const [status, setStatus] = useState<'idle' | 'loading' | 'loaded' | 'failed'>('idle');
-  const loadPolicy = useCallback(async () => {
+  useChainUpdateEffect(() => {
     if (!claimsManager) return;
 
-    setStatus('loading');
-    const result = await go(() => loadPolicies(claimsManager, { userAccount, policyId }));
+    const load = async () => {
+      setStatus('loading');
+      const result = await go(() => loadPolicies(claimsManager, { userAccount, policyId }));
 
-    if (!result.success) {
-      notifications.error({ message: messages.FAILED_TO_LOAD_POLICIES, errorOrMessage: result.error });
-      setStatus('failed');
-      return;
-    }
+      if (!result.success) {
+        notifications.error({ message: messages.FAILED_TO_LOAD_POLICIES, errorOrMessage: result.error });
+        setStatus('failed');
+        return;
+      }
 
-    setChainData(
-      'Loaded policy',
-      updateImmutablyCurried((state) => {
-        state.policies.byId = { ...state.policies.byId, ...result.data.byId };
-      })
-    );
-    setStatus('loaded');
+      setChainData(
+        'Loaded policy',
+        updateImmutablyCurried((state) => {
+          state.policies.byId = { ...state.policies.byId, ...result.data.byId };
+        })
+      );
+      setStatus('loaded');
+    };
+
+    load();
   }, [claimsManager, userAccount, policyId, setChainData]);
-
-  usePossibleChainDataUpdate(loadPolicy);
 
   return {
     data,

--- a/src/logic/policies/data.ts
+++ b/src/logic/policies/data.ts
@@ -1,14 +1,9 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { isWithinInterval } from 'date-fns';
 import { go } from '@api3/promise-utils';
 import { blockTimestampToDate, messages } from '../../utils';
 import { Policy, updateImmutablyCurried, useChainData } from '../../chain-data';
-import {
-  ClaimsManagerWithKlerosArbitration,
-  useClaimsManager,
-  usePossibleChainDataUpdate,
-  useChainUpdateEffect,
-} from '../../contracts';
+import { ClaimsManagerWithKlerosArbitration, useClaimsManager, useChainUpdateEffect } from '../../contracts';
 import { notifications } from '../../components/notifications';
 
 export function useUserPolicies() {
@@ -23,29 +18,31 @@ export function useUserPolicies() {
   }, [policies]);
 
   const [status, setStatus] = useState<'idle' | 'loading' | 'loaded' | 'failed'>('idle');
-  const loadUserPolicies = useCallback(async () => {
+  useChainUpdateEffect(() => {
     if (!claimsManager) return;
 
-    setStatus('loading');
-    const result = await go(() => loadPolicies(claimsManager, { userAccount }));
+    const load = async () => {
+      setStatus('loading');
+      const result = await go(() => loadPolicies(claimsManager, { userAccount }));
 
-    if (!result.success) {
-      notifications.error({ message: messages.FAILED_TO_LOAD_POLICIES, errorOrMessage: result.error });
-      setStatus('failed');
-      return;
-    }
+      if (!result.success) {
+        notifications.error({ message: messages.FAILED_TO_LOAD_POLICIES, errorOrMessage: result.error });
+        setStatus('failed');
+        return;
+      }
 
-    setChainData(
-      'Loaded policies',
-      updateImmutablyCurried((state) => {
-        state.policies.userPolicyIds = result.data.ids;
-        state.policies.byId = { ...state.policies.byId, ...result.data.byId };
-      })
-    );
-    setStatus('loaded');
+      setChainData(
+        'Loaded policies',
+        updateImmutablyCurried((state) => {
+          state.policies.userPolicyIds = result.data.ids;
+          state.policies.byId = { ...state.policies.byId, ...result.data.byId };
+        })
+      );
+      setStatus('loaded');
+    };
+
+    load();
   }, [claimsManager, userAccount, setChainData]);
-
-  usePossibleChainDataUpdate(loadUserPolicies);
 
   return {
     data: sortedPolicies,


### PR DESCRIPTION
### Problem statement
The existing `usePossibleChainDataUpdate()` hook accepts a callback that it triggers:
- on mount
- when account or network changes
- when a new block is mined

In my usage of this hook, my callback loads a policy by its id (which we get from the URL):
```ts
const callback = useCallback(async () => {
  // Load policy...
, [policyId]);

usePossibleChainDataUpdate(callback);
```
**The main issue:**
When you update the policy id in the URL, the callback doesn't get triggered again, and the UI gets out of sync.

**Additional issue:**
When multiple async calls are pending at the same time, there is no way to ensure that you only use the result from the latest call (as the async calls could resolve out of order).

### Proposed solution
Traditionally, these issues can be solved with `useEffect()`.

E.g. Basic example of loading data for a user (where user id can change at any time):
```ts
useEffect(() => {
  let isLatest = true;

  getData(userId).then(data => {
    if (isLatest) {
      setData(data);
    }
  });

  return {
    isLatest = false;
  }
}, [userId]);
```

So a solution would be to use a new hook that is similar to `useEffect()`, except that it also triggers:
- when account or network changes
- when a new block is mined

E.g. The same example as above, but with the new hook:
```ts
useChainUpdateEffect(() => {
  let isLatest = true;

  getData(userId).then(data => {
    if (isLatest) {
      setData(data);
    }
  });

  return {
    isLatest = false;
  }
}, [userId]);
```

Implementation details can be seen in this PR.

It's also worth noting that the `"react-hooks/exhaustive-deps"` Eslint rule can be extended to check custom hooks: 
```json
    "react-hooks/exhaustive-deps": [
      "warn",
      {
        "additionalHooks": "(useChainUpdateEffect)"
      }
    ]
```
<img width="966" alt="Screenshot 2022-08-03 at 11 39 46" src="https://user-images.githubusercontent.com/747979/182598369-4ef0ee62-98ff-40cd-a657-b99605f88658.png">

