### PR TITLE
DAO-196 Sanitise URL in ExternalLink component

### DIFF
--- a/src/components/external-link/external-link.test.tsx
+++ b/src/components/external-link/external-link.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import ExternalLink from './external-link';
+
+describe('<ExternalLink />', () => {
+  it('accepts an URL that starts with "https://"', () => {
+    render(<ExternalLink href="https://api3.org">API3</ExternalLink>);
+    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'https://api3.org');
+  });
+
+  it('accepts a mixed-case URL', () => {
+    render(<ExternalLink href="Https://api3.org">API3</ExternalLink>);
+    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'Https://api3.org');
+  });
+
+  it('accepts an URL that is padded with whitespace', () => {
+    render(<ExternalLink href=" https://api3.org ">API3</ExternalLink>);
+    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'https://api3.org');
+  });
+
+  it('rejects an URL that starts with "http://"', () => {
+    render(<ExternalLink href="http://api3.org">API3</ExternalLink>);
+    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'about:blank');
+  });
+
+  it('rejects a javascript URL', () => {
+    // eslint-disable-next-line no-script-url
+    render(<ExternalLink href="javascript:alert('xss')">API3</ExternalLink>);
+    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'about:blank');
+  });
+
+  it('rejects a data URL', () => {
+    render(<ExternalLink href="data:text/html,<script>alert('xss')</script>">API3</ExternalLink>);
+    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'about:blank');
+  });
+
+  it('rejects an URL without protocol', () => {
+    render(<ExternalLink href="api3.org">API3</ExternalLink>);
+    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'about:blank');
+  });
+});

--- a/src/components/external-link/external-link.test.tsx
+++ b/src/components/external-link/external-link.test.tsx
@@ -7,6 +7,11 @@ describe('<ExternalLink />', () => {
     expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'https://api3.org');
   });
 
+  it('accepts an URL that starts with "http://"', () => {
+    render(<ExternalLink href="http://api3.org">API3</ExternalLink>);
+    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'http://api3.org');
+  });
+
   it('accepts a mixed-case URL', () => {
     render(<ExternalLink href="Https://api3.org">API3</ExternalLink>);
     expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'Https://api3.org');
@@ -15,11 +20,6 @@ describe('<ExternalLink />', () => {
   it('accepts an URL that is padded with whitespace', () => {
     render(<ExternalLink href=" https://api3.org ">API3</ExternalLink>);
     expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'https://api3.org');
-  });
-
-  it('rejects an URL that starts with "http://"', () => {
-    render(<ExternalLink href="http://api3.org">API3</ExternalLink>);
-    expect(screen.getByRole('link', { name: 'API3' })).toHaveAttribute('href', 'about:blank');
   });
 
   it('rejects a javascript URL', () => {

--- a/src/components/external-link/external-link.tsx
+++ b/src/components/external-link/external-link.tsx
@@ -9,7 +9,13 @@ interface Props {
 }
 
 const ExternalLink = (props: Props) => {
-  const { className, href, children } = props;
+  const { className, children } = props;
+
+  let href = props.href.trim();
+  const urlRegex = /^https:\/\//i; // Starts with https:// (case insensitive)
+  if (!urlRegex.test(href)) {
+    href = 'about:blank';
+  }
 
   return (
     <a href={href} className={classNames(className, styles.link)} target="_blank" rel="noopener noreferrer">

--- a/src/components/external-link/external-link.tsx
+++ b/src/components/external-link/external-link.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import styles from './external-link.module.scss';
 
 interface Props {
@@ -12,10 +12,17 @@ const ExternalLink = (props: Props) => {
   const { className, children } = props;
 
   let href = props.href.trim();
-  const urlRegex = /^https:\/\//i; // Starts with https:// (case insensitive)
+  const urlRegex = /^https?:\/\//i; // Starts with https:// or http:// (case insensitive)
   if (!urlRegex.test(href)) {
     href = 'about:blank';
   }
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development' && href === 'about:blank') {
+      // eslint-disable-next-line no-console
+      console.warn(`An invalid URL has been provided: "${props.href}". Only https:// or http:// URLs are allowed.`);
+    }
+  }, [href, props.href]);
 
   return (
     <a href={href} className={classNames(className, styles.link)} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
### What does this change?
Updates the ExternalLink component to only accept URLs that start with "https://" or "http://"