### PR TITLE
DAO-194 Fix false positive w.r.t. EVM script mismatch

### DIFF
--- a/cypress/integration/malicious-proposal-validation.spec.ts
+++ b/cypress/integration/malicious-proposal-validation.spec.ts
@@ -34,7 +34,7 @@ describe('Malicious proposal validation', () => {
   it('does not show a warning if the original EVM script and the decoded EVM script matches up', () => {
     cy.increaseTimeAndRelogin(EPOCH_LENGTH + 60 * 60); // skip the genesis epoch (add 1 hour just to be sure)
     cy.exec(
-      `yarn create-proposal --type secondary --title 'API3 DAO BD-API Team Proposal' --description 'https://ipfs.fleek.co/ipfs/bafybeicfguu3bfhk3fyz5zn5wlujpksqxsaokse37674fhylouvsqnwd2m' --target-signature 'transfer(address,uint256)' --parameters '["0xCB943E4Fb0bCf7eC3C2E6D263c275b27F07701c6", "111363670000"]' --target-address 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 --target-value 0`
+      `yarn create-proposal --type secondary --title 'API3 DAO BD-API Team Proposal' --description 'https://ipfs.fleek.co/ipfs/bafybeicfguu3bfhk3fyz5zn5wlujpksqxsaokse37674fhylouvsqnwd2m' --target-signature 'transfer(address,uint256)' --parameters '["0xCB943E4Fb0bCf7eC3C2E6D263c275b27F07701c6", "111363670000"]' --target-address 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 --target-value 10`
     );
 
     cy.findAllByText('Governance').filter(':visible').click();

--- a/cypress/integration/new-proposal.spec.ts
+++ b/cypress/integration/new-proposal.spec.ts
@@ -44,12 +44,12 @@ it('new proposal form validation', () => {
   // Fill target address and value
   cy.findByText('Please specify a valid account address').should('exist');
   cy.findByLabelText('Target Contract Address').type(ACCOUNTS[1]);
-  cy.findByLabelText('ETH Value').type('-123456');
+  cy.findByLabelText('Value (Wei)').type('-123456');
   cy.findByText('Create').click();
 
-  // Fix the ETH value and create the proposal
-  cy.findByText('Please enter a valid non-negative amount in Wei').should('exist');
-  cy.findByLabelText('ETH Value').clear().type('123');
+  // Fix the value and create the proposal
+  cy.findByText('Please enter a valid amount in Wei').should('exist');
+  cy.findByLabelText('Value (Wei)').clear().type('123');
   cy.findByText('Create').click();
 
   // Expect the proposal to be created

--- a/cypress/integration/new-proposal.spec.ts
+++ b/cypress/integration/new-proposal.spec.ts
@@ -48,7 +48,7 @@ it('new proposal form validation', () => {
   cy.findByText('Create').click();
 
   // Fix the ETH value and create the proposal
-  cy.findByText('Please enter valid non-negative ETH amount').should('exist');
+  cy.findByText('Please enter a valid non-negative amount in Wei').should('exist');
   cy.findByLabelText('ETH Value').clear().type('123');
   cy.findByText('Create').click();
 

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -162,7 +162,9 @@ it('checks for positive ETH amount', async () => {
   const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
 
   assertGoError(goRes);
-  expect(goRes.error).toEqual(new EncodedEvmScriptError('targetValue', 'Please enter valid non-negative ETH amount'));
+  expect(goRes.error).toEqual(
+    new EncodedEvmScriptError('targetValue', 'Please enter a valid non-negative amount in Wei')
+  );
 });
 
 test('decoding', async () => {
@@ -172,7 +174,7 @@ test('decoding', async () => {
   assertGoSuccess(goRes);
   expect(await decodeEvmScript(mockedProvider, goRes.data, metadata)).toEqual({
     targetAddress: '0xB97F3A052d5562437e42EDeEBd1afec2376666eD',
-    value: utils.parseEther('12'),
+    value: BigNumber.from('12'),
     parameters: ['arg1', '123'],
   });
 });
@@ -189,7 +191,7 @@ describe('ENS name support', () => {
     assertGoSuccess(goRes);
     expect(await decodeEvmScript(mockedProvider, goRes.data, metadata)).toEqual({
       targetAddress: MOCKED_ENS_ENTRY.ensName,
-      value: utils.parseEther('12'),
+      value: BigNumber.from('12'),
       parameters: ['arg1', '123'],
     });
   });
@@ -206,7 +208,7 @@ describe('ENS name support', () => {
     assertGoSuccess(goRes);
     expect(await decodeEvmScript(mockedProvider, goRes.data, metadata)).toEqual({
       targetAddress: '0xB97F3A052d5562437e42EDeEBd1afec2376666eD',
-      value: utils.parseEther('12'),
+      value: BigNumber.from('12'),
       parameters: [MOCKED_ENS_ENTRY.ensName],
     });
   });
@@ -224,7 +226,7 @@ describe('ENS name support', () => {
 
     expect(await decodeEvmScript(mockedProvider, goRes.data, metadata)).toEqual({
       targetAddress: '0xB97F3A052d5562437e42EDeEBd1afec2376666eD',
-      value: utils.parseEther('12'),
+      value: BigNumber.from('12'),
       parameters: [address],
     });
   });

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -336,4 +336,64 @@ describe('isEvmScriptValid()', () => {
 
     expect(result).toBe(false);
   });
+
+  describe('when the proposal has a non-zero ETH value', () => {
+    it('returns true if the EVM script matches the original proposal data', async () => {
+      const script =
+        '0x00000001bb4c8c398288f2309b32dd83bc7dd3e4f93c605f000000e4b61d27f6000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000044a9059cbb000000000000000000000000cb943e4fb0bcf7ec3c2e6d263c275b27f07701c600000000000000000000000000000000000000000000000000000019edcabff000000000000000000000000000000000000000000000000000000000';
+      const metadata = {
+        description: 'https://ipfs.fleek.co/ipfs/bafybeicfguu3bfhk3fyz5zn5wlujpksqxsaokse37674fhylouvsqnwd2m',
+        targetSignature: 'transfer(address,uint256)',
+        title: 'API3 DAO BD-API Team Proposal',
+        version: '1',
+      };
+      const decodedEvmScript = await decodeEvmScript(mockedProvider, script, metadata);
+      expect(decodedEvmScript).not.toBeNull();
+      expect(decodedEvmScript!.value).toEqual(utils.parseEther('10'));
+
+      const result = await isEvmScriptValid(
+        mockedProvider,
+        { ...api3Agent, primary: '0xbb4c8c398288f2309b32dd83bc7dd3e4f93c605f' },
+        {
+          type: 'primary',
+          metadata,
+          decodedEvmScript,
+          script,
+        }
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false if the EVM script does not match the original proposal data', async () => {
+      const script =
+        '0x00000001bb4c8c398288f2309b32dd83bc7dd3e4f93c605f000000e4b61d27f6000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000044a9059cbb000000000000000000000000cb943e4fb0bcf7ec3c2e6d263c275b27f07701c600000000000000000000000000000000000000000000000000000019edcabff000000000000000000000000000000000000000000000000000000000';
+      /*
+        Original EVM script: transfer(address,uint256)
+        Decoded EVM script: transfer(address,int32)
+      */
+      const metadata = {
+        description: 'https://ipfs.fleek.co/ipfs/bafybeicfguu3bfhk3fyz5zn5wlujpksqxsaokse37674fhylouvsqnwd2m',
+        targetSignature: 'transfer(address,int32)',
+        title: 'API3 DAO BD-API Team Proposal',
+        version: '1',
+      };
+      const decodedEvmScript = await decodeEvmScript(mockedProvider, script, metadata);
+      expect(decodedEvmScript).not.toBeNull();
+      expect(decodedEvmScript!.value).toEqual(utils.parseEther('10'));
+
+      const result = await isEvmScriptValid(
+        mockedProvider,
+        { ...api3Agent, primary: '0xbb4c8c398288f2309b32dd83bc7dd3e4f93c605f' },
+        {
+          type: 'primary',
+          metadata,
+          decodedEvmScript,
+          script,
+        }
+      );
+
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -162,9 +162,7 @@ it('checks for positive ETH amount', async () => {
   const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
 
   assertGoError(goRes);
-  expect(goRes.error).toEqual(
-    new EncodedEvmScriptError('targetValue', 'Please enter a valid non-negative amount in Wei')
-  );
+  expect(goRes.error).toEqual(new EncodedEvmScriptError('targetValue', 'Please enter a valid amount in Wei'));
 });
 
 test('decoding', async () => {
@@ -339,7 +337,7 @@ describe('isEvmScriptValid()', () => {
     expect(result).toBe(false);
   });
 
-  describe('when the proposal has a non-zero ETH value', () => {
+  describe('when the proposal has a non-zero Wei value', () => {
     it('returns true if the EVM script matches the original proposal data', async () => {
       const script =
         '0x00000001bb4c8c398288f2309b32dd83bc7dd3e4f93c605f000000e4b61d27f6000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000044a9059cbb000000000000000000000000cb943e4fb0bcf7ec3c2e6d263c275b27f07701c600000000000000000000000000000000000000000000000000000019edcabff000000000000000000000000000000000000000000000000000000000';

--- a/src/logic/proposals/encoding/encoding.ts
+++ b/src/logic/proposals/encoding/encoding.ts
@@ -139,14 +139,14 @@ export const goEncodeEvmScript = async (
   }
   const targetAddress = goTargetAddress.data;
 
-  // Ensure value is non negative ether amount
+  // Ensure value is a non-negative amount (in Wei)
   const goValue = goSync(() => {
-    const parsed = utils.parseEther(formData.targetValue);
+    const parsed = BigNumber.from(formData.targetValue);
     if (parsed.lt(0)) throw new Error();
     return parsed;
   });
   if (!goValue.success) {
-    return fail(new EncodedEvmScriptError('targetValue', 'Please enter valid non-negative ETH amount'));
+    return fail(new EncodedEvmScriptError('targetValue', 'Please enter a valid non-negative amount in Wei'));
   }
   const targetValue = goValue.data;
 
@@ -268,7 +268,7 @@ export async function isEvmScriptValid(
       title: metadata.title,
       parameters: JSON.stringify(decodedEvmScript.parameters),
       targetAddress: decodedEvmScript.targetAddress,
-      targetValue: utils.formatEther(decodedEvmScript.value),
+      targetValue: decodedEvmScript.value.toString(),
     },
     api3Agent
   );

--- a/src/logic/proposals/encoding/encoding.ts
+++ b/src/logic/proposals/encoding/encoding.ts
@@ -268,7 +268,7 @@ export async function isEvmScriptValid(
       title: metadata.title,
       parameters: JSON.stringify(decodedEvmScript.parameters),
       targetAddress: decodedEvmScript.targetAddress,
-      targetValue: decodedEvmScript.value.toString(),
+      targetValue: utils.formatEther(decodedEvmScript.value),
     },
     api3Agent
   );

--- a/src/logic/proposals/encoding/encoding.ts
+++ b/src/logic/proposals/encoding/encoding.ts
@@ -146,7 +146,7 @@ export const goEncodeEvmScript = async (
     return parsed;
   });
   if (!goValue.success) {
-    return fail(new EncodedEvmScriptError('targetValue', 'Please enter a valid non-negative amount in Wei'));
+    return fail(new EncodedEvmScriptError('targetValue', 'Please enter a valid amount in Wei'));
   }
   const targetValue = goValue.data;
 

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -1,4 +1,4 @@
-import { BigNumber, utils } from 'ethers';
+import { BigNumber } from 'ethers';
 import { ComponentProps, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { Link } from 'react-router-dom';
@@ -248,7 +248,7 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
             {value.gt(0) && (
               <div className={styles.proposalDetailsItem}>
                 <p className={globalStyles.bold}>ETH Value</p>
-                <p className={globalStyles.secondaryColor}>{utils.formatEther(value)}</p>
+                <p className={globalStyles.secondaryColor}>{value.toString()}</p>
               </div>
             )}
             <div className={styles.proposalDetailsItem}>

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -247,7 +247,7 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
             </div>
             {value.gt(0) && (
               <div className={styles.proposalDetailsItem}>
-                <p className={globalStyles.bold}>ETH Value</p>
+                <p className={globalStyles.bold}>Value (Wei)</p>
                 <p className={globalStyles.secondaryColor}>{value.toString()}</p>
               </div>
             )}

--- a/src/pages/proposals/forms/new-proposal-form.tsx
+++ b/src/pages/proposals/forms/new-proposal-form.tsx
@@ -148,7 +148,7 @@ const NewProposalForm = (props: Props) => {
       </ProposalFormItem>
 
       <ProposalFormItem
-        name={<label htmlFor="target-value">ETH Value</label>}
+        name={<label htmlFor="target-value">Value (Wei)</label>}
         tooltip={`The amount of ETH you want to send along with the function call in Wei (use 0 unless the target function is "payable").`}
       >
         <Input


### PR DESCRIPTION
### What does this change?
It fixes a false positive. The "This proposal is potentially malicious" warning incorrectly shows when the proposal has a non-zero ETH value. We currently don't have any proposals on mainnet with a non-zero ETH value, so no false positives are currently showing on mainnet.

### How did you action this task?
Instead of providing the wei value to the `goEncodeEvmScript()` when re-encoding, the value gets formatted:

```diff
-  targetValue: decodedEvmScript.value.toString(),
+  targetValue: utils.formatEther(decodedEvmScript.value),
```
