### PR TITLE
DAO-192 Indicate when a ruling has been appealed

### DIFF
--- a/src/chain-data/state.ts
+++ b/src/chain-data/state.ts
@@ -139,6 +139,7 @@ export interface Claim {
     id: string;
     status: DisputeStatus;
     ruling: ArbitratorRuling;
+    appealedBy: null | string;
   };
 }
 

--- a/src/logic/claims/data.ts
+++ b/src/logic/claims/data.ts
@@ -24,6 +24,7 @@ import {
 } from '../../contracts';
 import { CreatedClaimEvent } from '../../contracts/tmp/ClaimsManager';
 import { CreatedDisputeEvent } from '../../contracts/tmp/arbitrators/KlerosLiquidProxy';
+import last from 'lodash/last';
 
 export function useUserClaims() {
   const { userAccount, claims, setChainData } = useChainData();
@@ -246,7 +247,10 @@ async function getDisputeContractData(contract: KlerosLiquidProxy, disputeEvents
 
   // Combine all calls so that we can make a single multicall
   const allCalls = [...disputeStatusCalls, ...currentRulingCalls];
-  const encodedResults = await contract.callStatic.multicall(allCalls);
+  const [encodedResults, appealEvents] = await Promise.all([
+    contract.callStatic.multicall(allCalls),
+    getAppealEvents(contract, disputeEvents),
+  ]);
 
   const disputeStatuses = encodedResults
     // Get the first batch of results
@@ -259,13 +263,27 @@ async function getDisputeContractData(contract: KlerosLiquidProxy, disputeEvents
     .map((res) => contract.interface.decodeFunctionResult('currentRuling', res));
 
   return disputeEvents.map((ev, index) => {
+    const disputeId = ev.args.disputeId.toString();
     const statusCode = disputeStatuses[index]?.[0] as DisputeStatusCode;
     const rulingCode = currentRulings[index]?.[0]?.toNumber() as ArbitratorRulingCode;
+    const appealers = appealEvents
+      .filter((appealEv) => appealEv.args.disputeId.toString() === disputeId)
+      .map((appealEv) => appealEv.args.sender);
+
     return {
       claimIndex: ev.args.claimIndex,
-      id: ev.args.disputeId.toString(),
+      id: disputeId,
       status: DisputeStatuses[statusCode],
       ruling: ArbitratorRulings[rulingCode],
+      appealedBy: last(appealers) ?? null,
     };
   });
+}
+
+async function getAppealEvents(contract: KlerosLiquidProxy, disputeEvents: CreatedDisputeEvent[]) {
+  const disputeIds = disputeEvents.map((ev) => ev.args.disputeId);
+  return await contract.queryFilter(
+    // @ts-expect-error For some reason Typechain doesn't recognise that you can provide an array
+    contract.filters.AppealedKlerosArbitratorRuling(null, null, disputeIds)
+  );
 }

--- a/src/logic/claims/data.ts
+++ b/src/logic/claims/data.ts
@@ -283,7 +283,7 @@ async function getDisputeContractData(contract: KlerosLiquidProxy, disputeEvents
 async function getAppealEvents(contract: KlerosLiquidProxy, disputeEvents: CreatedDisputeEvent[]) {
   const disputeIds = disputeEvents.map((ev) => ev.args.disputeId);
   return await contract.queryFilter(
-    // @ts-expect-error For some reason Typechain doesn't recognise that you can provide an array
+    // @ts-expect-error Typechain doesn't recognise that you can provide an array for any filter topic
     contract.filters.AppealedKlerosArbitratorRuling(null, null, disputeIds)
   );
 }

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -216,6 +216,39 @@ describe('<ClaimActions />', () => {
         expect(appealButton).toBeDisabled();
       });
     });
+
+    describe('when the ruling has been appealed', () => {
+      it('shows that it has been appealed to Kleros', () => {
+        claim.dispute = {
+          id: '1',
+          status: 'Waiting',
+          ruling: 'PaySettlement',
+          appealedBy: '0x153EF0B488148k0aB0FED112334',
+        };
+
+        render(<ClaimActions claim={claim} />);
+
+        expect(screen.getByText('0x153EF0B...2334')).toBeInTheDocument();
+        expect(screen.getByText(/Appealed to Kleros/i)).toBeInTheDocument();
+        expect(screen.queryByText('API3 Multi-sig')).not.toBeInTheDocument();
+        expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
+      });
+
+      it('shows that API3 has appealed when it is not the claimant', () => {
+        claim.dispute = {
+          id: '1',
+          status: 'Waiting',
+          ruling: 'PayClaim',
+          appealedBy: '0xD6b040736e948621c5b6E0a4944',
+        };
+
+        render(<ClaimActions claim={claim} />);
+
+        expect(screen.getByText('API3 Multi-sig')).toBeInTheDocument();
+        expect(screen.getByText(/Appealed to Kleros/i)).toBeInTheDocument();
+        expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
+      });
+    });
   });
 
   describe('"DisputeResolvedWithoutPayout" status', () => {

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -113,6 +113,7 @@ describe('<ClaimActions />', () => {
         id: '1',
         status: 'Waiting',
         ruling: 'DoNotPay',
+        appealedBy: null,
       };
 
       render(<ClaimActions claim={claim} />);
@@ -128,6 +129,7 @@ describe('<ClaimActions />', () => {
         id: '1',
         status: 'Waiting',
         ruling: 'DoNotPay',
+        appealedBy: null,
       };
 
       render(<ClaimActions claim={claim} />);
@@ -141,6 +143,7 @@ describe('<ClaimActions />', () => {
           id: '1',
           status: 'Solved',
           ruling: 'PayClaim',
+          appealedBy: null,
         };
 
         render(<ClaimActions claim={claim} />);
@@ -158,6 +161,7 @@ describe('<ClaimActions />', () => {
           id: '1',
           status: 'Appealable',
           ruling: 'PaySettlement',
+          appealedBy: null,
         };
       });
 
@@ -188,6 +192,7 @@ describe('<ClaimActions />', () => {
           id: '1',
           status: 'Appealable',
           ruling: 'DoNotPay',
+          appealedBy: null,
         };
       });
 


### PR DESCRIPTION
### What does this change?
It shows when a ruling has been appealed and distinguishes whether it was the claimant or API3 who appealed.

### How did you action this task?
The dispute object got a new `appealedBy` property which we use to determine if the ruling has been appealed (when the dispute `status` is `Waiting`)
```ts
  dispute: null | {
    id: string;
    status: DisputeStatus;
    ruling: ArbitratorRuling;
    appealedBy: null | string;
  };
```

### Screenshots
<img width="612" alt="Screenshot 2022-08-31 at 15 00 05" src="https://user-images.githubusercontent.com/747979/187684227-75556f71-8a9a-400d-a306-9459a2b3859c.png">
