### PR TITLE
Fix Dockerization issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds a mainnet version for API3 DAO dashboard
 
 FROM node:lts-alpine as builder
-RUN apk add --update --no-cache git
+RUN apk add --update --no-cache git $([ $(arch) == "aarch64" ] && echo "python3 make g++")
 WORKDIR /usr
 RUN git clone --depth=1 --branch production https://github.com/api3dao/api3-dao-dashboard.git
 RUN cd api3-dao-dashboard

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # This Dockerfile builds a mainnet version for API3 DAO dashboard
 
 FROM node:lts-alpine as builder
-RUN apk add --no-cache git
-WORKDIR /usr/src/app
-ADD . .
-RUN yarn 
+RUN apk add --update --no-cache git
+WORKDIR /usr
+RUN git clone --depth=1 --branch production https://github.com/api3dao/api3-dao-dashboard.git
+RUN cd api3-dao-dashboard
+WORKDIR /usr/api3-dao-dashboard
+RUN yarn
 RUN yarn build
 
 FROM nginx:alpine
 EXPOSE 80
-COPY --from=builder /usr/src/app/build /usr/share/nginx/html
+COPY --from=builder /usr/api3-dao-dashboard/build /usr/share/nginx/html
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ need `git` and `docker`. Note, that the production source code is on the `produc
 git clone --depth=1 --branch production https://github.com/api3dao/api3-dao-dashboard.git
 cd api3-dao-dashboard
 docker build --tag api3-dao-dashboard .
-docker run --detach --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
+docker run --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
 ```
 
 This will create a API3 dashboard running on port 7770 of your localhost where it is safe to connect your wallet.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,11 @@ need `git` and `docker`. Note, that the production source code is on the `produc
 git clone --depth=1 --branch production https://github.com/api3dao/api3-dao-dashboard.git
 cd api3-dao-dashboard
 docker build --tag api3-dao-dashboard .
-docker run --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
+docker run --rm --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
 ```
 
-This will create a API3 dashboard running on port 7770 of your localhost where it is safe to connect your wallet.
-
-Once you are finished interacting with the dashboard, the container can be stopped using
-`docker stop api3-dao-dashboard` and then removed using `docker rm api3-dao-dashboard`. To avoid having to execute the
-latter command to remove the container, add the `--rm` flag to the above `docker run` command.
+This will create a API3 dashboard running on port 7770 of your localhost where it is safe to connect your wallet. Once
+you are finished interacting with the dashboard, the container can be stopped using `docker stop api3-dao-dashboard`.
 
 ## Development instructions
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The decentralized approach of being a DAO member is to run API3 dashboard on you
 need `git` and `docker`. Note, that the production source code is on the `production` branch.
 
 ```
-git clone --depth=1 --branch production git@github.com:api3dao/api3-dao-dashboard.git
+git clone --depth=1 --branch production https://github.com/api3dao/api3-dao-dashboard.git
 cd api3-dao-dashboard
-docker build -t api3-dao-dashboard .
-docker run -d -p7770:80 --name api3-dao-dashboard api3-dao-dashboard
+docker build --tag api3-dao-dashboard .
+docker run --detach --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
 ```
 
 This will create a API3 dashboard running on port 7770 of your localhost where it is safe to connect your wallet.
@@ -26,6 +26,8 @@ latter command to remove the container, add the `--rm` flag to the above `docker
 
 We use the `main` branch to develop new features. For production code, see the
 [the production branch](https://github.com/api3dao/api3-dao-dashboard/tree/production).
+
+Currently, it's only possible to develop on UNIX-like OS. If you use Windows, you can use WSL2.
 
 ### Running on mainnet or testnets
 


### PR DESCRIPTION
Fixes https://linear.app/api3-dao/issue/DAO-205/verify-dao-dashboard-in-docker-works-on-all-platforms

## Description

Initially it was reported that the dockerized version is not working on Windows, but I realized it doesn't work also on the new m1 macOS (due to a different issue). 

* The windows issue is caused by broken symlinks when cloning the repo locally. This also means it's not possible to develop using Windows for which I've added a note. The fix is to clone the repo inside docker (again).
* MacOS issue is caused by missing libraries and we had the [same issue in Airnode](https://github.com/api3dao/airnode/blob/master/docker/Dockerfile#L5) so I just copied over the solution.

I've also changed the instructions in the README to clone the repo using HTTPS instead of SSH since the SSH requires more setup and is not really needed.

## Code changes

* First two commits fix the docker issues for Windows and macOS.
* Last two commits are changes docker run parameters. These are opinionated, but I'd argue these parameters are better suited. If you disagree I can just drop them.

## Tested

I followed the README steps with one change. Instead of running:
```sh
git clone --depth=1 --branch production https://github.com/api3dao/api3-dao-dashboard.git
```

I run

```sh
git clone --depth=1 --branch dao-205 https://github.com/api3dao/api3-dao-dashboard.git
```

Tested on:
- m1 macOS
- WSL2 (Windows), which is essentially Linux
- Windows (using PowerShell)
