### PR TITLE
DAO-207 Prevent overwriting an existing localhost-dao.json file in postinstall script

### DIFF
--- a/dev-scripts/copy-localhost-data.js
+++ b/dev-scripts/copy-localhost-data.js
@@ -1,11 +1,25 @@
 /**
  * For localhost development, we depend on `localhost-dao.json` file which is gitignored because it will change after
- * each redeployment of the DAO contracts. However, we have to make sure it is created when before build the
+ * each redeployment of the DAO contracts. However, we have to make sure it is created before we build the
  * application.
  */
+const { join } = require('path');
+const { existsSync } = require('fs');
+const isEqual = require('lodash/isEqual');
 const { promiseWrapper, execAndLog } = require('./utils');
+const exampleAddresses = require('../src/contract-deployments/localhost-dao.example.json');
 
 const main = async () => {
+  const localAddressesPath = join(__dirname, '../src/contract-deployments/localhost-dao.json');
+  if (existsSync(localAddressesPath)) {
+    // We prevent overwriting an existing localhost-dao.json file if its keys (i.e. the contract names)
+    // matches the example file's keys.
+    const localAddresses = require(localAddressesPath);
+    if (isEqual(Object.keys(localAddresses), Object.keys(exampleAddresses))) {
+      return;
+    }
+  }
+
   await execAndLog('cd src/contract-deployments && cp localhost-dao.example.json localhost-dao.json');
 };
 


### PR DESCRIPTION
### What does this change?
It prevents overwriting an existing `localhost-dao.json` file in the postinstall script, so that you don't lose your deployed addresses unnecessarily.

### How did you action this task?
If there is an existing `localhost-dao.json` file, we only continue overwriting it if its keys (i.e. contract names) don't match the example file's keys.