### PR TITLE
DAO-200 Extend the summary section on the Claim Details page

### DIFF
--- a/src/chain-data/state.ts
+++ b/src/chain-data/state.ts
@@ -129,7 +129,7 @@ export interface Claim {
   claimant: string;
   beneficiary: string;
   claimAmountInUsd: BigNumber;
-  counterOfferAmountInUsd: null | BigNumber;
+  settlementAmountInUsd: null | BigNumber;
   status: ClaimStatus;
   statusUpdatedAt: Date;
   deadline: null | Date;

--- a/src/logic/claims/data.ts
+++ b/src/logic/claims/data.ts
@@ -140,7 +140,7 @@ async function loadClaims(
 ) {
   const { userAccount = null, claimId = null } = params;
   // Get all the static data via events
-  const [createdEvents, counterOfferEvents, disputeEvents] = await Promise.all([
+  const [createdEvents, settlementEvents, disputeEvents] = await Promise.all([
     claimsManager.queryFilter(claimsManager.filters.CreatedClaim(claimId, userAccount)),
     claimsManager.queryFilter(claimsManager.filters.ProposedSettlement(claimId, userAccount)),
     arbitratorProxy.queryFilter(arbitratorProxy.filters.CreatedDispute(claimId, userAccount)),
@@ -161,7 +161,7 @@ async function loadClaims(
     const eventArgs = event.args;
     const claimId = eventArgs.claimHash;
     const claimData = claims[index]!;
-    const counterOfferEvent = counterOfferEvents.find((ev) => ev.args.claimHash === claimId);
+    const settlementEvent = settlementEvents.find((ev) => ev.args.claimHash === claimId);
     const dispute = disputes.find((dispute) => dispute.claimId === claimId);
     const policy = policies.find((policy) => policy.id === eventArgs.policyHash)!;
 
@@ -172,7 +172,7 @@ async function loadClaims(
       claimant: eventArgs.claimant,
       beneficiary: eventArgs.beneficiary,
       claimAmountInUsd: eventArgs.claimAmountInUsd,
-      settlementAmountInUsd: counterOfferEvent?.args.settlementAmountInUsd ?? null,
+      settlementAmountInUsd: settlementEvent?.args.settlementAmountInUsd ?? null,
       status: ClaimStatuses[claimData.status as ClaimStatusCode],
       statusUpdatedAt: blockTimestampToDate(claimData.updateTime),
       deadline: null,

--- a/src/logic/claims/data.ts
+++ b/src/logic/claims/data.ts
@@ -172,7 +172,7 @@ async function loadClaims(
       claimant: eventArgs.claimant,
       beneficiary: eventArgs.beneficiary,
       claimAmountInUsd: eventArgs.claimAmountInUsd,
-      counterOfferAmountInUsd: counterOfferEvent?.args.settlementAmountInUsd ?? null,
+      settlementAmountInUsd: counterOfferEvent?.args.settlementAmountInUsd ?? null,
       status: ClaimStatuses[claimData.status as ClaimStatusCode],
       statusUpdatedAt: blockTimestampToDate(claimData.updateTime),
       deadline: null,

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -14,7 +14,7 @@ describe('<ClaimActions />', () => {
       claimant: '0x153EF0B488148k0aB0FED112334',
       beneficiary: '0x153EF0B488148k0aB0FED112334',
       claimAmountInUsd: parseUsd('1000'),
-      counterOfferAmountInUsd: null,
+      settlementAmountInUsd: null,
       timestamp: addDays(new Date(), -2),
       status: 'ClaimCreated',
       statusUpdatedAt: addDays(new Date(), -1),
@@ -63,7 +63,7 @@ describe('<ClaimActions />', () => {
   describe('"SettlementProposed" status', () => {
     it('enables Accept and Escalate actions', () => {
       claim.status = 'SettlementProposed';
-      claim.counterOfferAmountInUsd = parseUsd('500');
+      claim.settlementAmountInUsd = parseUsd('500');
       claim.deadline = addMinutes(new Date(), 1);
 
       render(<ClaimActions claim={claim} payout={null} />);
@@ -78,7 +78,7 @@ describe('<ClaimActions />', () => {
 
     it('disables the buttons when the deadline has passed', () => {
       claim.status = 'SettlementProposed';
-      claim.counterOfferAmountInUsd = parseUsd('500');
+      claim.settlementAmountInUsd = parseUsd('500');
       claim.deadline = addMinutes(new Date(), -1);
 
       render(<ClaimActions claim={claim} payout={null} />);
@@ -93,7 +93,7 @@ describe('<ClaimActions />', () => {
   describe('"SettlementAccepted" status', () => {
     it('shows claimant has accepted the counter', () => {
       claim.status = 'SettlementAccepted';
-      claim.counterOfferAmountInUsd = parseUsd('500');
+      claim.settlementAmountInUsd = parseUsd('500');
       const payout = {
         amountInUsd: parseUsd('500'),
         amountInApi3: parseApi3('250'),
@@ -132,7 +132,7 @@ describe('<ClaimActions />', () => {
     });
 
     it('shows counter offer amount when present', () => {
-      claim.counterOfferAmountInUsd = parseUsd('500');
+      claim.settlementAmountInUsd = parseUsd('500');
       claim.dispute = {
         id: '1',
         status: 'Waiting',
@@ -168,7 +168,7 @@ describe('<ClaimActions />', () => {
 
     describe('with "PaySettlement" arbitrator ruling', () => {
       beforeEach(() => {
-        claim.counterOfferAmountInUsd = parseUsd('500');
+        claim.settlementAmountInUsd = parseUsd('500');
         claim.dispute = {
           id: '1',
           status: 'Appealable',
@@ -323,7 +323,7 @@ describe('<ClaimActions />', () => {
   describe('"DisputeResolvedWithSettlementPayout" status', () => {
     it('shows the claim counter offer has been approved', () => {
       claim.status = 'DisputeResolvedWithSettlementPayout';
-      claim.counterOfferAmountInUsd = parseUsd('500');
+      claim.settlementAmountInUsd = parseUsd('500');
       claim.deadline = addMinutes(new Date(), 1);
       const payout = {
         amountInUsd: parseUsd('500'),

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -163,7 +163,7 @@ export default function ClaimActions(props: Props) {
         <div className={styles.actionSection}>
           <p>API3 Multi-sig</p>
           <div className={styles.actionMainInfo}>
-            Countered with <br />${formatUsd(claim.counterOfferAmountInUsd!)}
+            Countered with <br />${formatUsd(claim.settlementAmountInUsd!)}
           </div>
           <div className={styles.actionPanel}>
             <Button variant="primary" disabled={disableActions} onClick={handleAcceptCounter}>
@@ -193,7 +193,7 @@ export default function ClaimActions(props: Props) {
           <p>{abbrStr(claim.claimant)}</p>
           <div className={styles.actionMainInfo}>
             Accepted <br />
-            counter of <br />${formatUsd(claim.counterOfferAmountInUsd!)}
+            counter of <br />${formatUsd(claim.settlementAmountInUsd!)}
             <PayoutAmount claim={claim} payout={props.payout!} />
           </div>
           <p className={styles.actionMessage}>All done! The settlement has been accepted.</p>
@@ -219,9 +219,9 @@ export default function ClaimActions(props: Props) {
         return (
           <div className={styles.actionSection}>
             <p>{abbrStr(claim.claimant)}</p>
-            {claim.counterOfferAmountInUsd?.gt(0) ? (
+            {claim.settlementAmountInUsd?.gt(0) ? (
               <div className={styles.actionMainInfo}>
-                Escalated counter of <br />${formatUsd(claim.counterOfferAmountInUsd!)} <br />
+                Escalated counter of <br />${formatUsd(claim.settlementAmountInUsd!)} <br />
                 to Kleros
               </div>
             ) : (
@@ -259,7 +259,7 @@ export default function ClaimActions(props: Props) {
                 </span>
                 <br />
                 {' counter of '}
-                <br />${formatUsd(claim.counterOfferAmountInUsd!)}
+                <br />${formatUsd(claim.settlementAmountInUsd!)}
               </div>
               <div className={styles.actionPanel}>
                 <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('appeal')}>
@@ -342,7 +342,7 @@ export default function ClaimActions(props: Props) {
             </span>
             <br />
             {' counter of '}
-            <br />${formatUsd(claim.counterOfferAmountInUsd!)}
+            <br />${formatUsd(claim.settlementAmountInUsd!)}
             <PayoutAmount claim={claim} payout={props.payout!} />
           </div>
           <p className={styles.actionMessage}>All done! The settlement has been paid out.</p>

--- a/src/pages/claim-details/claim-details.module.scss
+++ b/src/pages/claim-details/claim-details.module.scss
@@ -27,3 +27,22 @@
     margin-bottom: 0;
   }
 }
+
+.labelWithTooltip {
+  display: flex;
+  align-items: center;
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    background: transparent;
+    border: none;
+    margin-left: 0.5ch;
+  }
+}
+
+.disputeLink {
+  color: $primary-color;
+  font-size: $text-small;
+  font-weight: 500;
+}

--- a/src/pages/claim-details/claim-details.tsx
+++ b/src/pages/claim-details/claim-details.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import { BaseLayout } from '../../components/layout';
 import BorderedBox, { Header } from '../../components/bordered-box';
 import ExternalLink from '../../components/external-link';
@@ -141,6 +142,12 @@ function ClaimSummary(props: ClaimSummaryProps) {
           ) : (
             <Skeleton width="8ch" />
           )}
+        </p>
+      </div>
+      <div className={styles.detailsItem}>
+        <p className={globalStyles.bold}>Service Coverage Policy</p>
+        <p className={globalStyles.secondaryColor}>
+          <Link to={`/policies/${claim.policy.id}`}>{claim.policy.metadata}</Link>
         </p>
       </div>
       <div className={styles.detailsItem}>

--- a/src/pages/claim-details/claim-details.tsx
+++ b/src/pages/claim-details/claim-details.tsx
@@ -115,7 +115,7 @@ function ClaimSummary(props: ClaimSummaryProps) {
         <p className={globalStyles.bold}>Claim Amount</p>
         <p className={globalStyles.secondaryColor}>${formatUsd(claim.claimAmountInUsd)}</p>
       </div>
-      {claim.counterOfferAmountInUsd && (
+      {claim.settlementAmountInUsd && (
         <div className={styles.detailsItem}>
           <p className={`${globalStyles.bold} ${styles.labelWithTooltip}`}>
             Proposed Settlement Amount
@@ -129,7 +129,7 @@ function ClaimSummary(props: ClaimSummaryProps) {
               </button>
             </Tooltip>
           </p>
-          <p className={globalStyles.secondaryColor}>${formatUsd(claim.counterOfferAmountInUsd)}</p>
+          <p className={globalStyles.secondaryColor}>${formatUsd(claim.settlementAmountInUsd)}</p>
         </div>
       )}
       <div className={styles.detailsItem}>

--- a/src/pages/claim-details/payout-amount.tsx
+++ b/src/pages/claim-details/payout-amount.tsx
@@ -16,7 +16,7 @@ export default function PayoutAmount(props: Props) {
     switch (claim.status) {
       case 'SettlementAccepted':
       case 'DisputeResolvedWithSettlementPayout':
-        return claim.counterOfferAmountInUsd!;
+        return claim.settlementAmountInUsd!;
       default:
         return claim.claimAmountInUsd;
     }


### PR DESCRIPTION
### What does this change?
- adds 
  - proposed settlement amount
  - remaining service coverage amount
  - link to Policy Details page
  - link to Kleros dispute resolver
- renames counterOfferAmountInUsd -> settlementAmountInUsd (copy changes will follow in [DAO-217](https://linear.app/api3-dao/issue/DAO-217))
  
### Screenshots
<img width="1054" alt="Screenshot 2022-10-04 at 11 25 59" src="https://user-images.githubusercontent.com/747979/193784715-3347c8ed-49f4-4a3f-8d2a-6102d45b42bf.png">
