### PR TITLE
DAO-206 Add Execute Payout action for when the bot fails to execute the ruling for the user

### DIFF
--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -336,6 +336,22 @@ task('resolve-dispute', 'Resolves the dispute for the claim')
     console.info(`Resolved dispute: ${args.disputeId}`);
   });
 
+task(
+  'pass-dispute-period',
+  'Progresses the dispute into its next period (given that the current period end date has passed)'
+)
+  .addParam('disputeId', 'The arbitrator dispute ID')
+  .setAction(async (args, hre) => {
+    const accounts = await hre.ethers.getSigners();
+
+    // The index for the deployer needs to be in sync with the deploy script
+    const deployer = accounts[0];
+    const contracts = getContractAddresses(hre.network.name);
+    const arbitrator = MockKlerosArbitratorFactory.connect(contracts.arbitrator, deployer);
+    await arbitrator.passPeriod(args.disputeId);
+    console.info(`Dispute: ${args.disputeId} has passed into its next period`);
+  });
+
 // See https://hardhat.org/config/
 const config: HardhatUserConfig = {
   // https://hardhat.org/hardhat-network/#connecting-to-hardhat-network-from-wallets-and-other-software

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "claims:arbitrator-decide-to-pay": "cd hardhat && npx hardhat give-dispute-ruling --ruling 1",
     "claims:arbitrator-decide-to-pay-settlement": "cd hardhat && npx hardhat give-dispute-ruling --ruling 2",
     "claims:resolve-dispute": "cd hardhat && npx hardhat resolve-dispute",
+    "claims:pass-dispute-period": "cd hardhat && npx hardhat pass-dispute-period",
     "start": "BROWSER=none react-scripts start",
     "test:watch": "react-scripts test",
     "test": "react-scripts test --watchAll=false",

--- a/src/chain-data/state.ts
+++ b/src/chain-data/state.ts
@@ -115,7 +115,8 @@ export type TransactionType =
   | 'create-claim'
   | 'accept-claim-settlement'
   | 'escalate-claim-to-arbitrator'
-  | 'appeal-claim-decision';
+  | 'appeal-claim-decision'
+  | 'execute-claim-payout';
 
 interface Vesting {
   amountVested: BigNumber;

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -149,7 +149,7 @@ describe('<ClaimActions />', () => {
 
     describe('with "PayClaim" arbitrator ruling', () => {
       it('shows the claim has been approved', () => {
-        claim.deadline = addMinutes(new Date(), 2);
+        claim.deadline = addDays(new Date(), 2);
         claim.dispute = {
           id: '1',
           status: 'Appealable',
@@ -196,7 +196,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'PaySettlement',
           period: 'Appeal',
-          periodEndDate: addDays(new Date(), 1),
+          periodEndDate: addMinutes(new Date(), 1),
           appealedBy: null,
         };
 
@@ -216,7 +216,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'PaySettlement',
           period: 'Appeal',
-          periodEndDate: addDays(new Date(), -1),
+          periodEndDate: addMinutes(new Date(), -1),
           appealedBy: null,
         };
 
@@ -252,7 +252,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'DoNotPay',
           period: 'Appeal',
-          periodEndDate: addDays(new Date(), 1),
+          periodEndDate: addMinutes(new Date(), 1),
           appealedBy: null,
         };
 
@@ -272,7 +272,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'DoNotPay',
           period: 'Appeal',
-          periodEndDate: addDays(new Date(), -1),
+          periodEndDate: addMinutes(new Date(), -1),
           appealedBy: null,
         };
 

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -149,6 +149,24 @@ describe('<ClaimActions />', () => {
 
     describe('with "PayClaim" arbitrator ruling', () => {
       it('shows the claim has been approved', () => {
+        claim.deadline = addMinutes(new Date(), 2);
+        claim.dispute = {
+          id: '1',
+          status: 'Appealable',
+          ruling: 'PayClaim',
+          period: 'Appeal',
+          periodEndDate: addDays(new Date(), 2),
+          appealedBy: null,
+        };
+
+        render(<ClaimActions claim={claim} payout={null} />);
+
+        expect(screen.getByText(/Kleros/i)).toBeInTheDocument();
+        expect(screen.getByTestId('status-message')).toHaveTextContent(/Approved full amount/i);
+        expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
+      });
+
+      it('provides an Execute Payout action when in the "Execution" period', () => {
         claim.dispute = {
           id: '1',
           status: 'Solved',
@@ -160,27 +178,27 @@ describe('<ClaimActions />', () => {
 
         render(<ClaimActions claim={claim} payout={null} />);
 
-        expect(screen.getByText(/Kleros/i)).toBeInTheDocument();
-        expect(screen.getByTestId('status-message')).toHaveTextContent(/Approved full amount/i);
-        expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
+        const payoutButton = screen.getByRole('button', { name: /Execute Payout/i });
+        expect(payoutButton).not.toBeDisabled();
+        expect(screen.queryAllByRole('button')).toHaveLength(1); // There should only be the one action
       });
     });
 
     describe('with "PaySettlement" arbitrator ruling', () => {
       beforeEach(() => {
         claim.settlementAmountInUsd = parseUsd('500');
+      });
+
+      it('provides an Appeal action when in the "Appeal" period', () => {
+        claim.deadline = addMinutes(new Date(), 1);
         claim.dispute = {
           id: '1',
           status: 'Appealable',
           ruling: 'PaySettlement',
           period: 'Appeal',
-          periodEndDate: addDays(new Date(), 2),
+          periodEndDate: addDays(new Date(), 1),
           appealedBy: null,
         };
-      });
-
-      it('provides an Appeal action', () => {
-        claim.deadline = addMinutes(new Date(), 1);
 
         render(<ClaimActions claim={claim} payout={null} />);
 
@@ -188,32 +206,55 @@ describe('<ClaimActions />', () => {
         expect(screen.getByTestId('status-message')).toHaveTextContent(/Approved counter of \$500.0/i);
         const appealButton = screen.getByRole('button', { name: /Appeal/i });
         expect(appealButton).not.toBeDisabled();
+        expect(screen.queryAllByRole('button')).toHaveLength(1); // There should only be the one action
       });
 
       it('disables the Appeal button when the deadline has passed', () => {
         claim.deadline = addMinutes(new Date(), -1);
+        claim.dispute = {
+          id: '1',
+          status: 'Appealable',
+          ruling: 'PaySettlement',
+          period: 'Appeal',
+          periodEndDate: addDays(new Date(), -1),
+          appealedBy: null,
+        };
 
         render(<ClaimActions claim={claim} payout={null} />);
 
         const appealButton = screen.getByRole('button', { name: /Appeal/i });
         expect(appealButton).toBeDisabled();
       });
+
+      it('provides an Execute Payout action when in the "Execution" period', () => {
+        claim.dispute = {
+          id: '1',
+          status: 'Solved',
+          ruling: 'PaySettlement',
+          period: 'Execution',
+          periodEndDate: null,
+          appealedBy: null,
+        };
+
+        render(<ClaimActions claim={claim} payout={null} />);
+
+        const payoutButton = screen.getByRole('button', { name: /Execute Payout/i });
+        expect(payoutButton).not.toBeDisabled();
+        expect(screen.queryAllByRole('button')).toHaveLength(1); // There should only be the one action
+      });
     });
 
     describe('with "DoNotPay" arbitrator ruling', () => {
-      beforeEach(() => {
+      it('provides an Appeal action when in the "Appeal" period', () => {
+        claim.deadline = addMinutes(new Date(), 1);
         claim.dispute = {
           id: '1',
           status: 'Appealable',
           ruling: 'DoNotPay',
           period: 'Appeal',
-          periodEndDate: addDays(new Date(), 2),
+          periodEndDate: addDays(new Date(), 1),
           appealedBy: null,
         };
-      });
-
-      it('provides an Appeal action', () => {
-        claim.deadline = addMinutes(new Date(), 1);
 
         render(<ClaimActions claim={claim} payout={null} />);
 
@@ -221,15 +262,39 @@ describe('<ClaimActions />', () => {
         expect(screen.getByText(/Rejected/i)).toBeInTheDocument();
         const appealButton = screen.getByRole('button', { name: /Appeal/i });
         expect(appealButton).not.toBeDisabled();
+        expect(screen.queryAllByRole('button')).toHaveLength(1); // There should only be the one action
       });
 
       it('disables the Appeal button when the deadline has passed', () => {
         claim.deadline = addMinutes(new Date(), -1);
+        claim.dispute = {
+          id: '1',
+          status: 'Appealable',
+          ruling: 'DoNotPay',
+          period: 'Appeal',
+          periodEndDate: addDays(new Date(), -1),
+          appealedBy: null,
+        };
 
         render(<ClaimActions claim={claim} payout={null} />);
 
         const appealButton = screen.getByRole('button', { name: /Appeal/i });
         expect(appealButton).toBeDisabled();
+      });
+
+      it('provides no action when in the "Execution" period', () => {
+        claim.dispute = {
+          id: '1',
+          status: 'Solved',
+          ruling: 'DoNotPay',
+          period: 'Execution',
+          periodEndDate: null,
+          appealedBy: null,
+        };
+
+        render(<ClaimActions claim={claim} payout={null} />);
+
+        expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
       });
     });
 

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -101,7 +101,6 @@ export default function ClaimActions(props: Props) {
         transactions: [...transactions, { type: 'execute-claim-payout', tx }],
       });
       setStatus('submitted');
-      setModalToShow(null);
     } else {
       setStatus('failed');
     }

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -93,6 +93,20 @@ export default function ClaimActions(props: Props) {
     }
   };
 
+  const handleExecutePayout = async () => {
+    setStatus('submitting');
+    const tx = await handleTransactionError(arbitratorProxy.executeRuling(claim.dispute!.id));
+    if (tx) {
+      setChainData('Execute claim payout transaction', {
+        transactions: [...transactions, { type: 'execute-claim-payout', tx }],
+      });
+      setStatus('submitted');
+      setModalToShow(null);
+    } else {
+      setStatus('failed');
+    }
+  };
+
   const handleModalClose = () => setModalToShow(null);
 
   switch (claim.status) {
@@ -245,6 +259,13 @@ export default function ClaimActions(props: Props) {
                 <br />
                 {' full amount'}
               </div>
+              {dispute.period === 'Execution' && (
+                <div className={styles.actionPanel}>
+                  <Button variant="secondary" disabled={disableActions} onClick={handleExecutePayout}>
+                    Execute Payout
+                  </Button>
+                </div>
+              )}
             </div>
           );
 
@@ -261,22 +282,33 @@ export default function ClaimActions(props: Props) {
                 {' counter of '}
                 <br />${formatUsd(claim.settlementAmountInUsd!)}
               </div>
-              <div className={styles.actionPanel}>
-                <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('appeal')}>
-                  Appeal
-                </Button>
-                <Modal open={modalToShow === 'appeal'} onClose={handleModalClose}>
-                  <AppealConfirmation
-                    disputeId={claim.dispute!.id}
-                    disableActions={disableActions}
-                    onConfirm={handleAppeal}
-                    onCancel={handleModalClose}
-                  />
-                </Modal>
-              </div>
-              <p className={styles.actionMessage}>
-                You can appeal within the given time frame or the counter offer will be automatically accepted.
-              </p>
+              {dispute.period === 'Appeal' && (
+                <>
+                  <div className={styles.actionPanel}>
+                    <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('appeal')}>
+                      Appeal
+                    </Button>
+                    <Modal open={modalToShow === 'appeal'} onClose={handleModalClose}>
+                      <AppealConfirmation
+                        disputeId={claim.dispute!.id}
+                        disableActions={disableActions}
+                        onConfirm={handleAppeal}
+                        onCancel={handleModalClose}
+                      />
+                    </Modal>
+                  </div>
+                  <p className={styles.actionMessage}>
+                    You can appeal within the given time frame or the counter offer will be automatically accepted.
+                  </p>
+                </>
+              )}
+              {dispute.period === 'Execution' && (
+                <div className={styles.actionPanel}>
+                  <Button variant="secondary" disabled={disableActions} onClick={handleExecutePayout}>
+                    Execute Payout
+                  </Button>
+                </div>
+              )}
             </div>
           );
 
@@ -285,22 +317,26 @@ export default function ClaimActions(props: Props) {
             <div className={styles.actionSection}>
               <p>Kleros</p>
               <div className={styles.actionMainInfo}>Rejected</div>
-              <div className={styles.actionPanel}>
-                <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('appeal')}>
-                  Appeal
-                </Button>
-                <Modal open={modalToShow === 'appeal'} onClose={handleModalClose}>
-                  <AppealConfirmation
-                    disputeId={claim.dispute!.id}
-                    disableActions={disableActions}
-                    onConfirm={handleAppeal}
-                    onCancel={handleModalClose}
-                  />
-                </Modal>
-              </div>
-              <p className={styles.actionMessage}>
-                You can appeal within the given time frame or the rejection will be automatically accepted.
-              </p>
+              {dispute.period === 'Appeal' && (
+                <>
+                  <div className={styles.actionPanel}>
+                    <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('appeal')}>
+                      Appeal
+                    </Button>
+                    <Modal open={modalToShow === 'appeal'} onClose={handleModalClose}>
+                      <AppealConfirmation
+                        disputeId={claim.dispute!.id}
+                        disableActions={disableActions}
+                        onConfirm={handleAppeal}
+                        onCancel={handleModalClose}
+                      />
+                    </Modal>
+                  </div>
+                  <p className={styles.actionMessage}>
+                    You can appeal within the given time frame or the rejection will be automatically accepted.
+                  </p>
+                </>
+              )}
             </div>
           );
 

--- a/src/pages/claim-details/claim-details.tsx
+++ b/src/pages/claim-details/claim-details.tsx
@@ -158,7 +158,7 @@ function ClaimSummary(props: ClaimSummaryProps) {
       </div>
       <div className={styles.detailsItem}>
         <p className={globalStyles.bold}>Claim Created</p>
-        <p className={globalStyles.secondaryColor}>{format(claim.timestamp, 'do MMMM yyyy hh:mm')}</p>
+        <p className={globalStyles.secondaryColor}>{format(claim.timestamp, 'do MMMM yyyy HH:mm')}</p>
       </div>
     </div>
   );

--- a/src/pages/claim-details/payout-amount.tsx
+++ b/src/pages/claim-details/payout-amount.tsx
@@ -34,7 +34,7 @@ export default function PayoutAmount(props: Props) {
   };
 
   const renderTooltip = () => {
-    const formattedDate = format(claim.statusUpdatedAt, 'dd MMM yyyy hh:mm');
+    const formattedDate = format(claim.statusUpdatedAt, 'dd MMM yyyy HH:mm');
 
     return payout.amountInUsd.lt(getAmountToPayInUsd()) ? (
       <p>

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -146,4 +146,9 @@ export const transactionMessages: { [key in TransactionType]: PendingTransaction
     success: 'Success! Claim decision has been appealed.',
     error: 'Failed to appeal decision. Please try again.',
   },
+  'execute-claim-payout': {
+    start: 'Executing payout...',
+    success: 'Success! Claim has been paid out.',
+    error: 'Failed to execute payout. Please try again.',
+  },
 };


### PR DESCRIPTION
The bot should take care of executing the ruling for the user, so this Execute Payout action is needed for the when the bot fails to do its job (a corner case).

### What does this change?
- adds a Execute Payout action when the arbitrator gave a `PayClaim` or a `PaySettlement` ruling, and the dispute is in the `Execution` period
- adds a `pass-dispute-period` Hardhat task in order to progress the dispute from the `Appeal` period to the `Execution` period

**Usage e.g.**
```
yarn claims:arbitrator-decide-to-pay-settlement --dispute-id 1 --appeal-period-length 0
yarn claims:pass-dispute-period --dispute-id 1
```
