### PR TITLE
DAO-221 Policy and Claim Details header updates

### DIFF
--- a/src/components/back-button/back-button.module.scss
+++ b/src/components/back-button/back-button.module.scss
@@ -9,7 +9,6 @@
   text-decoration: none;
   font-size: $text-small;
   line-height: $lh-small;
-  margin-bottom: 10px;
   background: transparent;
   border: none;
   cursor: pointer;

--- a/src/pages/claim-details/claim-details.module.scss
+++ b/src/pages/claim-details/claim-details.module.scss
@@ -5,7 +5,8 @@
   align-items: center;
   gap: 10px;
   font-size: $text-small;
-  color: $secondary-color;
+  color: $tertiary-color;
+  font-weight: 400;
   margin-bottom: 10px;
 
   & > * {

--- a/src/pages/claim-details/claim-details.module.scss
+++ b/src/pages/claim-details/claim-details.module.scss
@@ -1,5 +1,24 @@
 @import '../../styles/variables.module.scss';
 
+.backButtonRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: $text-small;
+  color: $secondary-color;
+  margin-bottom: 10px;
+
+  & > * {
+    padding: 0 6px;
+  }
+
+  span {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+}
+
 .detailsHeader {
   @media (min-width: $min-md) {
     display: flex;

--- a/src/pages/claim-details/claim-details.tsx
+++ b/src/pages/claim-details/claim-details.tsx
@@ -9,7 +9,7 @@ import Skeleton from '../../components/skeleton';
 import { Tooltip } from '../../components/tooltip';
 import ClaimActions from './claim-actions';
 import { useParams } from 'react-router';
-import { abbrStr, useChainData, Claim } from '../../chain-data';
+import { useChainData, Claim } from '../../chain-data';
 import { useUserClaimDataById, getCurrentDeadline } from '../../logic/claims';
 import { useUserPolicyById } from '../../logic/policies';
 import { format } from 'date-fns';
@@ -42,9 +42,6 @@ export default function ClaimDetails() {
   if (!claim) {
     return (
       <ClaimDetailsLayout claimId={claimId}>
-        <div className={styles.detailsHeader}>
-          <h4>Claim {abbrStr(claimId)}</h4>
-        </div>
         {status === 'loading' && <p className={globalStyles.secondaryColor}>Loading...</p>}
         {status === 'loaded' && <p>Unable to find your claim with given id.</p>}
       </ClaimDetailsLayout>
@@ -55,7 +52,7 @@ export default function ClaimDetails() {
   return (
     <ClaimDetailsLayout claimId={claimId}>
       <div className={styles.detailsHeader}>
-        <h4>Claim {abbrStr(claimId)}</h4>
+        <h4>{claim.policy.metadata}</h4>
         {deadline && <Timer size="large" deadline={deadline} onDeadlineExceeded={forceUpdate} showDeadline />}
       </div>
       <ClaimActions key={claim.status} claim={claim} payout={payout} />
@@ -85,8 +82,10 @@ interface ClaimDetailsLayoutProps {
 function ClaimDetailsLayout(props: ClaimDetailsLayoutProps) {
   return (
     <BaseLayout subtitle={`Claim ${props.claimId}`}>
-      <div>
+      <div className={styles.backButtonRow}>
         <BackButton fallback={{ href: '/claims' }}>Back</BackButton>
+        {' | '}
+        <span>Claim ID: {props.claimId}</span>
       </div>
       {props.children}
     </BaseLayout>

--- a/src/pages/components/proposal-details/proposal-details.module.scss
+++ b/src/pages/components/proposal-details/proposal-details.module.scss
@@ -1,24 +1,7 @@
 @import '../../../styles/variables.module.scss';
 
-.backLink {
-  display: inline-flex;
-  align-items: center;
-  color: $secondary-color;
-  text-decoration: none;
-  font-size: $text-small;
-  line-height: $lh-small;
-}
-
-.proposalDetailsSubheader {
-  display: flex;
-  align-items: center;
+.backButtonRow {
   margin-bottom: 10px;
-  & > * {
-    margin-right: $space-md;
-  }
-  & > *:last-child {
-    margin-right: 0;
-  }
 }
 
 .scrollX {

--- a/src/pages/components/proposal-details/proposal-details.module.scss
+++ b/src/pages/components/proposal-details/proposal-details.module.scss
@@ -12,6 +12,7 @@
 .proposalDetailsSubheader {
   display: flex;
   align-items: center;
+  margin-bottom: 10px;
   & > * {
     margin-right: $space-md;
   }

--- a/src/pages/components/proposal-details/proposal-details.module.scss
+++ b/src/pages/components/proposal-details/proposal-details.module.scss
@@ -1,6 +1,7 @@
 @import '../../../styles/variables.module.scss';
 
 .backButtonRow {
+  font-weight: 400;
   margin-bottom: 10px;
 }
 

--- a/src/pages/components/proposal-details/proposal-details.tsx
+++ b/src/pages/components/proposal-details/proposal-details.tsx
@@ -131,7 +131,7 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
 
   return (
     <div>
-      <div className={styles.proposalDetailsSubheader}>
+      <div className={styles.backButtonRow}>
         <BackButton fallback={{ href: proposal.open ? '/governance' : '/history' }}>Back</BackButton>
       </div>
 

--- a/src/pages/policy-details/policy-details.module.scss
+++ b/src/pages/policy-details/policy-details.module.scss
@@ -1,5 +1,24 @@
 @import '../../styles/variables.module.scss';
 
+.backButtonRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: $text-small;
+  color: $secondary-color;
+  margin-bottom: 10px;
+
+  & > * {
+    padding: 0 6px;
+  }
+
+  span {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+}
+
 .heading {
   margin-bottom: 100px;
   word-break: break-word;

--- a/src/pages/policy-details/policy-details.module.scss
+++ b/src/pages/policy-details/policy-details.module.scss
@@ -5,8 +5,8 @@
   align-items: center;
   gap: 10px;
   font-size: $text-small;
-  color: $secondary-color;
-  margin-bottom: 10px;
+  font-weight: 400;
+  color: $tertiary-color;
 
   & > * {
     padding: 0 6px;
@@ -19,9 +19,39 @@
   }
 }
 
-.heading {
+.header {
   margin-bottom: 100px;
+}
+
+.heading {
   word-break: break-word;
+  margin: 10px 0;
+}
+
+.extraInfo {
+  display: flex;
+  gap: 16px;
+  color: $tertiary-color;
+  font-size: $text-small;
+  font-weight: 400;
+
+  .divider,
+  .allowedUntil {
+    display: none;
+    @media (min-width: $min-sm) {
+      display: inline;
+    }
+  }
+}
+
+.active {
+  color: $green-color;
+  font-weight: 600;
+}
+
+.inactive {
+  color: $pink-color;
+  font-weight: 600;
 }
 
 .detailsSection {
@@ -31,6 +61,13 @@
     font-size: $text-small;
     line-height: $lh-small;
     margin: 0 0 $space-xxl;
+  }
+
+  .allowedUntil {
+    display: block;
+    @media (min-width: $min-sm) {
+      display: none;
+    }
   }
 }
 

--- a/src/pages/policy-details/policy-details.tsx
+++ b/src/pages/policy-details/policy-details.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { BaseLayout } from '../../components/layout';
 import BorderedBox, { Header } from '../../components/bordered-box';
 import Button from '../../components/button';
@@ -33,20 +34,16 @@ export default function PolicyDetails() {
 
   if (!policy) {
     return (
-      <BaseLayout subtitle={`Policy ${policyId}`}>
-        <h4 className={styles.heading}>Policy</h4>
+      <PolicyDetailsLayout policyId={policyId}>
         {status === 'loading' && <p className={globalStyles.secondaryColor}>Loading...</p>}
         {status === 'loaded' && <p>Unable to find your policy with given id.</p>}
-      </BaseLayout>
+      </PolicyDetailsLayout>
     );
   }
 
   const policyIpfsHref = getIpfsUrl(policy.ipfsHash);
   return (
-    <BaseLayout subtitle={`Policy ${policyId}`}>
-      <div>
-        <BackButton fallback={{ href: '/policies' }}>Back</BackButton>
-      </div>
+    <PolicyDetailsLayout policyId={policyId}>
       <h4 className={styles.heading}>{policy.metadata}</h4>
       <BorderedBox
         noMobileBorders
@@ -107,6 +104,24 @@ export default function PolicyDetails() {
           </div>
         }
       />
+    </PolicyDetailsLayout>
+  );
+}
+
+interface PolicyDetailsLayoutProps {
+  policyId: string;
+  children: ReactNode;
+}
+
+function PolicyDetailsLayout(props: PolicyDetailsLayoutProps) {
+  return (
+    <BaseLayout subtitle={`Policy ${props.policyId}`}>
+      <div className={styles.backButtonRow}>
+        <BackButton fallback={{ href: '/policies' }}>Back</BackButton>
+        {' | '}
+        <span>Policy ID: {props.policyId}</span>
+      </div>
+      {props.children}
     </BaseLayout>
   );
 }

--- a/src/pages/policy-details/policy-details.tsx
+++ b/src/pages/policy-details/policy-details.tsx
@@ -9,7 +9,7 @@ import { format } from 'date-fns';
 import { formatUsd, getIpfsUrl, useScrollToTop } from '../../utils';
 import { useHistory, useParams } from 'react-router';
 import { useChainData } from '../../chain-data';
-import { canCreateClaim, useUserPolicyById } from '../../logic/policies';
+import { canCreateClaim, isActive, useUserPolicyById } from '../../logic/policies';
 import globalStyles from '../../styles/global-styles.module.scss';
 import styles from './policy-details.module.scss';
 
@@ -44,7 +44,22 @@ export default function PolicyDetails() {
   const policyIpfsHref = getIpfsUrl(policy.ipfsHash);
   return (
     <PolicyDetailsLayout policyId={policyId}>
-      <h4 className={styles.heading}>{policy.metadata}</h4>
+      <header className={styles.header}>
+        <h4 className={styles.heading}>{policy.metadata}</h4>
+        <div className={styles.extraInfo}>
+          {isActive(policy) ? (
+            <span className={styles.active}>Active</span>
+          ) : (
+            <span className={styles.inactive}>Inactive</span>
+          )}
+          <span className={styles.divider}>{' | '}</span>
+          <span className={styles.allowedUntil}>
+            Claims Allowed Until:{' '}
+            <span className={globalStyles.primaryColor}>{format(policy.claimsAllowedUntil, 'do MMMM yyyy')} </span>
+            {format(policy.claimsAllowedUntil, 'HH:mm')}
+          </span>
+        </div>
+      </header>
       <BorderedBox
         noMobileBorders
         header={
@@ -80,20 +95,16 @@ export default function PolicyDetails() {
               <p className={globalStyles.secondaryColor}>{policy.beneficiary}</p>
             </div>
             <div className={styles.detailsItem}>
-              <p className={globalStyles.bold}>Service Coverage Amount</p>
+              <p className={globalStyles.bold}>Remaining Service Coverage Amount</p>
               <p className={globalStyles.secondaryColor}>${formatUsd(policy.remainingCoverageInUsd)}</p>
             </div>
             <div className={styles.detailsItem}>
               <p className={globalStyles.bold}>Claims Allowed From</p>
               <p className={globalStyles.secondaryColor}>{format(policy.claimsAllowedFrom, 'do MMMM yyyy HH:mm')}</p>
             </div>
-            <div className={styles.detailsItem}>
+            <div className={`${styles.detailsItem} ${styles.allowedUntil}`}>
               <p className={globalStyles.bold}>Claims Allowed Until</p>
               <p className={globalStyles.secondaryColor}>{format(policy.claimsAllowedUntil, 'do MMMM yyyy HH:mm')}</p>
-            </div>
-            <div className={styles.detailsItem}>
-              <p className={globalStyles.bold}>Policy Hash</p>
-              <p className={globalStyles.secondaryColor}>{policy.policyId}</p>
             </div>
             <div className={styles.detailsItem}>
               <p className={globalStyles.bold}>Service Coverage Terms and Conditions</p>


### PR DESCRIPTION
### What does this change?
- adds Policy ID, Active/Inactive, and Claims Allowed Until to Policy Details header
- adds Claim ID to Claim Details header

### Screenshots
**Policy Details**
<img width="1084" alt="Screenshot 2022-10-11 at 16 51 11" src="https://user-images.githubusercontent.com/747979/195128125-3fb2b951-fd06-4742-8077-a1385ebd6823.png">

<img width="373" alt="Screenshot 2022-10-11 at 16 52 46" src="https://user-images.githubusercontent.com/747979/195128412-3183779f-88fd-4ed3-8a83-cc6e9580fa41.png">

**Claim Details**
<img width="1052" alt="Screenshot 2022-10-11 at 16 53 57" src="https://user-images.githubusercontent.com/747979/195128697-c144687a-3c8b-4105-a5ff-3fa6d739dcfd.png">
