### PR TITLE
DAO-217 Update claim states on Claim Details page

### DIFF
--- a/src/pages/claim-details/claim-actions.module.scss
+++ b/src/pages/claim-details/claim-actions.module.scss
@@ -11,6 +11,10 @@
   word-break: break-word;
 }
 
+.heading {
+  margin-bottom: 40px;
+}
+
 .actionMainInfo {
   font-size: $heading-5;
   line-height: $lh-heading-5;

--- a/src/pages/claim-details/claim-actions.module.scss
+++ b/src/pages/claim-details/claim-actions.module.scss
@@ -14,8 +14,8 @@
 .actionMainInfo {
   font-size: $heading-5;
   line-height: $lh-heading-5;
-  font-weight: bold;
-  margin-bottom: 4rem;
+  font-weight: 600;
+  margin-bottom: 40px;
 }
 
 .approved {
@@ -44,7 +44,33 @@
 }
 
 .actionMessage {
-  color: $tertiary-color;
-  font-weight: 400;
   max-width: 52ch;
+}
+
+.coverageMessage {
+  margin-top: 40px;
+  max-width: 52ch;
+}
+
+.mediator {
+  display: flex;
+  align-items: center;
+  svg {
+    height: 18px;
+  }
+}
+
+.arbitrator {
+  display: flex;
+  align-items: center;
+  svg {
+    height: 18px;
+  }
+}
+
+.warningIcon {
+  color: $pink-color;
+  transform: translateY(5px);
+  width: 24px;
+  margin-right: 1ch;
 }

--- a/src/pages/claim-details/claim-actions.module.scss
+++ b/src/pages/claim-details/claim-actions.module.scss
@@ -6,9 +6,16 @@
   align-items: center;
   color: $secondary-color;
   text-align: center;
-  margin-top: 4rem;
-  margin-bottom: 4rem;
   word-break: break-word;
+  margin-top: $space-xxl;
+  margin-bottom: 4rem;
+  padding-bottom: 4rem;
+  border-bottom: 1px solid $black-line-color;
+
+  @media (min-width: $min-sm) {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
 }
 
 .heading {
@@ -22,6 +29,22 @@
   margin-bottom: 40px;
 }
 
+.mediator {
+  display: flex;
+  align-items: center;
+  svg {
+    height: 18px;
+  }
+}
+
+.arbitrator {
+  display: flex;
+  align-items: center;
+  svg {
+    height: 18px;
+  }
+}
+
 .approved {
   color: $green-color;
   svg {
@@ -33,6 +56,13 @@
   color: $pink-color;
   svg {
     margin-right: 0.75ch;
+  }
+}
+
+.usdAmount {
+  @media (min-width: $min-sm) {
+    font-size: $text-xlarge;
+    line-height: $lh-heading-3;
   }
 }
 
@@ -54,22 +84,6 @@
 .coverageMessage {
   margin-top: 40px;
   max-width: 52ch;
-}
-
-.mediator {
-  display: flex;
-  align-items: center;
-  svg {
-    height: 18px;
-  }
-}
-
-.arbitrator {
-  display: flex;
-  align-items: center;
-  svg {
-    height: 18px;
-  }
 }
 
 .warningIcon {

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -44,8 +44,8 @@ describe('<ClaimActions />', () => {
 
         expect(screen.getByTestId('status-prefix')).toHaveTextContent('API3 Mediators');
         expect(screen.getByTestId('status')).toHaveTextContent('Rejected');
-        const appealButton = screen.getByRole('button', { name: /Escalate to Kleros/i });
-        expect(appealButton).not.toBeDisabled();
+        const escalateButton = screen.getByRole('button', { name: /Escalate to Kleros/i });
+        expect(escalateButton).not.toBeDisabled();
       });
 
       it('removes the Escalate button when the new deadline has passed', () => {
@@ -73,9 +73,9 @@ describe('<ClaimActions />', () => {
       expect(screen.getByTestId('status')).toHaveTextContent('Offered Settlement');
       expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
       const acceptButton = screen.getByRole('button', { name: /Accept Settlement/i });
-      const appealButton = screen.getByRole('button', { name: /Escalate to Kleros/i });
+      const escalateButton = screen.getByRole('button', { name: /Escalate to Kleros/i });
       expect(acceptButton).not.toBeDisabled();
-      expect(appealButton).not.toBeDisabled();
+      expect(escalateButton).not.toBeDisabled();
     });
 
     it('shows that proposed settlement has timed out', () => {
@@ -165,6 +165,7 @@ describe('<ClaimActions />', () => {
 
         expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
         expect(screen.getByTestId('status')).toHaveTextContent(/^Accepted$/);
+        expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^1,000.0 USD/);
         expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
       });
 

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -71,6 +71,7 @@ describe('<ClaimActions />', () => {
 
       expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
       expect(screen.getByTestId('status')).toHaveTextContent('Offered Settlement');
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
       const acceptButton = screen.getByRole('button', { name: /Accept Settlement/i });
       const appealButton = screen.getByRole('button', { name: /Escalate to Kleros/i });
       expect(acceptButton).not.toBeDisabled();
@@ -103,6 +104,7 @@ describe('<ClaimActions />', () => {
 
       expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
       expect(screen.getByTestId('status')).toHaveTextContent('Settled');
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
       expect(screen.getByRole('button', { name: /View payout info/i })).toBeInTheDocument();
       expect(screen.queryAllByRole('button')).toHaveLength(1); // There should be no other actions available
     });
@@ -187,6 +189,7 @@ describe('<ClaimActions />', () => {
 
         expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
         expect(screen.getByTestId('status')).toHaveTextContent('Accepted Settlement');
+        expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
         const appealButton = screen.getByRole('button', { name: /Appeal/i });
         expect(appealButton).not.toBeDisabled();
         expect(screen.queryAllByRole('button')).toHaveLength(1); // There should only be the one action
@@ -346,6 +349,7 @@ describe('<ClaimActions />', () => {
 
       expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
       expect(screen.getByTestId('status')).toHaveTextContent(/Accepted$/);
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^1,000.0 USD/);
       expect(screen.getByRole('button', { name: /View payout info/i })).toBeInTheDocument();
       expect(screen.queryAllByRole('button')).toHaveLength(1); // There should be no other actions available
     });
@@ -364,6 +368,7 @@ describe('<ClaimActions />', () => {
 
       expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
       expect(screen.getByTestId('status')).toHaveTextContent(/Accepted$/);
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^1,000.0 USD/);
       expect(screen.getByRole('button', { name: /View payout info/i })).toBeInTheDocument();
       expect(screen.queryAllByRole('button')).toHaveLength(1); // There should be no other actions available
     });
@@ -384,6 +389,7 @@ describe('<ClaimActions />', () => {
 
       expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
       expect(screen.getByTestId('status')).toHaveTextContent('Settled');
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
       expect(screen.getByRole('button', { name: /View payout info/i })).toBeInTheDocument();
       expect(screen.queryAllByRole('button')).toHaveLength(1); // There should be no other actions available
     });

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -31,7 +31,7 @@ describe('<ClaimActions />', () => {
 
       render(<ClaimActions claim={claim} payout={null} />);
 
-      expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
+      expect(screen.getByTestId('status-prefix')).toHaveTextContent('API3 Mediators');
       expect(screen.getByTestId('status')).toHaveTextContent('Evaluating');
     });
 
@@ -42,7 +42,7 @@ describe('<ClaimActions />', () => {
 
         render(<ClaimActions claim={claim} payout={null} />);
 
-        expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
+        expect(screen.getByTestId('status-prefix')).toHaveTextContent('API3 Mediators');
         expect(screen.getByTestId('status')).toHaveTextContent('Rejected');
         const appealButton = screen.getByRole('button', { name: /Escalate to Kleros/i });
         expect(appealButton).not.toBeDisabled();
@@ -54,7 +54,7 @@ describe('<ClaimActions />', () => {
 
         render(<ClaimActions claim={claim} payout={null} />);
 
-        expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
+        expect(screen.getByTestId('status-prefix')).toHaveTextContent('API3 Mediators');
         expect(screen.getByTestId('status')).toHaveTextContent('Rejected');
         expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
       });
@@ -69,7 +69,7 @@ describe('<ClaimActions />', () => {
 
       render(<ClaimActions claim={claim} payout={null} />);
 
-      expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
+      expect(screen.getByTestId('status-prefix')).toHaveTextContent('API3 Mediators');
       expect(screen.getByTestId('status')).toHaveTextContent('Offered Settlement');
       expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
       const acceptButton = screen.getByRole('button', { name: /Accept Settlement/i });
@@ -102,11 +102,28 @@ describe('<ClaimActions />', () => {
 
       render(<ClaimActions claim={claim} payout={payout} />);
 
-      expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
+      expect(screen.getByTestId('status-prefix')).toHaveTextContent('API3 Mediators');
       expect(screen.getByTestId('status')).toHaveTextContent('Settled');
       expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
       expect(screen.getByRole('button', { name: /View payout info/i })).toBeInTheDocument();
       expect(screen.queryAllByRole('button')).toHaveLength(1); // There should be no other actions available
+    });
+
+    it('informs the user when the payout amount has been clipped', () => {
+      claim.status = 'SettlementAccepted';
+      claim.settlementAmountInUsd = parseUsd('500');
+      const payout = {
+        amountInUsd: parseUsd('400'),
+        amountInApi3: parseApi3('200'),
+        transactionHash: '0xfc83f22fb8167f9cdfb982dd4aeccc84d70df1494bca8271b3428d74df73807a',
+      };
+
+      render(<ClaimActions claim={claim} payout={payout} />);
+
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^400.0 USD/);
+      expect(screen.getByTestId('notifications')).toHaveTextContent(
+        'The full settlement (500.0 USD) exceeded the remaining coverage'
+      );
     });
   });
 
@@ -127,7 +144,7 @@ describe('<ClaimActions />', () => {
 
       render(<ClaimActions claim={claim} payout={null} />);
 
-      expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
+      expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
       expect(screen.getByTestId('status')).toHaveTextContent('Evaluating');
       expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
     });
@@ -146,8 +163,8 @@ describe('<ClaimActions />', () => {
 
         render(<ClaimActions claim={claim} payout={null} />);
 
-        expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
-        expect(screen.getByTestId('status')).toHaveTextContent(/Accepted$/);
+        expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
+        expect(screen.getByTestId('status')).toHaveTextContent(/^Accepted$/);
         expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
       });
 
@@ -187,7 +204,7 @@ describe('<ClaimActions />', () => {
 
         render(<ClaimActions claim={claim} payout={null} />);
 
-        expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
+        expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
         expect(screen.getByTestId('status')).toHaveTextContent('Accepted Settlement');
         expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
         const appealButton = screen.getByRole('button', { name: /Appeal/i });
@@ -244,7 +261,7 @@ describe('<ClaimActions />', () => {
 
         render(<ClaimActions claim={claim} payout={null} />);
 
-        expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
+        expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
         expect(screen.getByTestId('status')).toHaveTextContent('Rejected');
         const appealButton = screen.getByRole('button', { name: /Appeal/i });
         expect(appealButton).not.toBeDisabled();
@@ -297,9 +314,9 @@ describe('<ClaimActions />', () => {
 
         render(<ClaimActions claim={claim} payout={null} />);
 
-        expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
+        expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
         expect(screen.getByTestId('status')).toHaveTextContent('Evaluating');
-        expect(screen.getByText(/You appealed Kleros’s ruling/i)).toBeInTheDocument();
+        expect(screen.getByTestId('notifications')).toHaveTextContent('You appealed Kleros’s ruling');
         expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
       });
 
@@ -315,9 +332,9 @@ describe('<ClaimActions />', () => {
 
         render(<ClaimActions claim={claim} payout={null} />);
 
-        expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
+        expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
         expect(screen.getByTestId('status')).toHaveTextContent('Evaluating');
-        expect(screen.getByText(/The API3 Mediators appealed Kleros’s ruling/i)).toBeInTheDocument();
+        expect(screen.getByTestId('notifications')).toHaveTextContent('The API3 Mediators appealed Kleros’s ruling');
         expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
       });
     });
@@ -330,7 +347,7 @@ describe('<ClaimActions />', () => {
 
       render(<ClaimActions claim={claim} payout={null} />);
 
-      expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
+      expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
       expect(screen.getByTestId('status')).toHaveTextContent('Rejected');
       expect(screen.queryAllByRole('button')).toHaveLength(0); // There should be no actions available
     });
@@ -347,11 +364,27 @@ describe('<ClaimActions />', () => {
 
       render(<ClaimActions claim={claim} payout={payout} />);
 
-      expect(screen.getByTestId('actor')).toHaveTextContent('API3 Mediators');
-      expect(screen.getByTestId('status')).toHaveTextContent(/Accepted$/);
+      expect(screen.getByTestId('status-prefix')).toHaveTextContent('API3 Mediators');
+      expect(screen.getByTestId('status')).toHaveTextContent(/^Accepted$/);
       expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^1,000.0 USD/);
       expect(screen.getByRole('button', { name: /View payout info/i })).toBeInTheDocument();
       expect(screen.queryAllByRole('button')).toHaveLength(1); // There should be no other actions available
+    });
+
+    it('informs the user when the payout amount has been clipped', () => {
+      claim.status = 'ClaimAccepted';
+      const payout = {
+        amountInUsd: parseUsd('800'),
+        amountInApi3: parseApi3('400'),
+        transactionHash: '0xfc83f22fb8167f9cdfb982dd4aeccc84d70df1494bca8271b3428d74df73807a',
+      };
+
+      render(<ClaimActions claim={claim} payout={payout} />);
+
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^800.0 USD/);
+      expect(screen.getByTestId('notifications')).toHaveTextContent(
+        'The full payout (1,000.0 USD) exceeded the remaining coverage'
+      );
     });
   });
 
@@ -366,11 +399,27 @@ describe('<ClaimActions />', () => {
 
       render(<ClaimActions claim={claim} payout={payout} />);
 
-      expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
-      expect(screen.getByTestId('status')).toHaveTextContent(/Accepted$/);
+      expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
+      expect(screen.getByTestId('status')).toHaveTextContent(/^Accepted$/);
       expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^1,000.0 USD/);
       expect(screen.getByRole('button', { name: /View payout info/i })).toBeInTheDocument();
       expect(screen.queryAllByRole('button')).toHaveLength(1); // There should be no other actions available
+    });
+
+    it('informs the user when the payout amount has been clipped', () => {
+      claim.status = 'DisputeResolvedWithClaimPayout';
+      const payout = {
+        amountInUsd: parseUsd('800'),
+        amountInApi3: parseApi3('400'),
+        transactionHash: '0xfc83f22fb8167f9cdfb982dd4aeccc84d70df1494bca8271b3428d74df73807a',
+      };
+
+      render(<ClaimActions claim={claim} payout={payout} />);
+
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^800.0 USD/);
+      expect(screen.getByTestId('notifications')).toHaveTextContent(
+        'The full payout (1,000.0 USD) exceeded the remaining coverage'
+      );
     });
   });
 
@@ -378,7 +427,6 @@ describe('<ClaimActions />', () => {
     it('shows the claim counter offer has been approved', () => {
       claim.status = 'DisputeResolvedWithSettlementPayout';
       claim.settlementAmountInUsd = parseUsd('500');
-      claim.deadline = addMinutes(new Date(), 1);
       const payout = {
         amountInUsd: parseUsd('500'),
         amountInApi3: parseApi3('250'),
@@ -387,11 +435,28 @@ describe('<ClaimActions />', () => {
 
       render(<ClaimActions claim={claim} payout={payout} />);
 
-      expect(screen.getByTestId('actor')).toHaveTextContent('Kleros');
+      expect(screen.getByTestId('status-prefix')).toHaveTextContent('Kleros');
       expect(screen.getByTestId('status')).toHaveTextContent('Settled');
       expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^500.0 USD/);
       expect(screen.getByRole('button', { name: /View payout info/i })).toBeInTheDocument();
       expect(screen.queryAllByRole('button')).toHaveLength(1); // There should be no other actions available
+    });
+
+    it('informs the user when the payout amount has been clipped', () => {
+      claim.status = 'DisputeResolvedWithSettlementPayout';
+      claim.settlementAmountInUsd = parseUsd('500');
+      const payout = {
+        amountInUsd: parseUsd('400'),
+        amountInApi3: parseApi3('200'),
+        transactionHash: '0xfc83f22fb8167f9cdfb982dd4aeccc84d70df1494bca8271b3428d74df73807a',
+      };
+
+      render(<ClaimActions claim={claim} payout={payout} />);
+
+      expect(screen.getByTestId('usd-amount')).toHaveTextContent(/^400.0 USD/);
+      expect(screen.getByTestId('notifications')).toHaveTextContent(
+        'The full settlement (500.0 USD) exceeded the remaining coverage'
+      );
     });
   });
 });

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -122,11 +122,11 @@ export default function ClaimActions(props: Props) {
         if (isPastNewDeadline) {
           return (
             <div className={styles.actionSection}>
-              <p className={styles.mediator}>
+              <p className={styles.mediator} data-testid="actor">
                 <Api3Icon aria-hidden /> API3 Mediators
               </p>
               <div className={styles.actionMainInfo}>
-                <span className={styles.rejected}>
+                <span className={styles.rejected} data-testid="status">
                   <CloseIcon aria-hidden />
                   Rejected
                 </span>
@@ -142,11 +142,13 @@ export default function ClaimActions(props: Props) {
         const disableEscalate = status === 'submitting' || status === 'submitted';
         return (
           <div className={styles.actionSection}>
-            <p className={styles.mediator}>
+            <p className={styles.mediator} data-testid="actor">
               <Api3Icon aria-hidden /> API3 Mediators
             </p>
             <div className={styles.actionMainInfo}>
-              <span className={globalStyles.primaryColor}>Rejected</span>
+              <span className={globalStyles.primaryColor} data-testid="status">
+                Rejected
+              </span>
             </div>
             <div className={styles.actionPanel}>
               <Button variant="secondary" disabled={disableEscalate} onClick={() => setModalToShow('escalate')}>
@@ -169,10 +171,12 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.mediator}>
+          <p className={styles.mediator} data-testid="actor">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
-          <div className={styles.actionMainInfo}>Evaluating</div>
+          <div className={styles.actionMainInfo} data-testid="status">
+            Evaluating
+          </div>
           <p className={styles.actionMessage}>API3 Mediators are currently evaluating your claim</p>
         </div>
       );
@@ -183,11 +187,11 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.mediator}>
+          <p className={styles.mediator} data-testid="actor">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
           <div className={styles.actionMainInfo}>
-            <span className={styles.approved}>
+            <span className={styles.approved} data-testid="status">
               <CheckIcon aria-hidden />
               Accepted
             </span>
@@ -214,7 +218,9 @@ export default function ClaimActions(props: Props) {
         return (
           <div className={styles.actionSection}>
             <div className={styles.actionMainInfo}>
-              <span className={globalStyles.primaryColor}>Timed Out</span>
+              <span className={globalStyles.primaryColor} data-testid="status">
+                Timed Out
+              </span>
             </div>
             <p className={styles.actionMessage}>
               A settlement was offered by the API3 Mediators and wasn’t accepted within the required time period
@@ -225,11 +231,13 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.mediator}>
+          <p className={styles.mediator} data-testid="actor">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
           <div className={styles.actionMainInfo}>
-            <div className={globalStyles.primaryColor}>Offered Settlement</div>
+            <div className={globalStyles.primaryColor} data-testid="status">
+              Offered Settlement
+            </div>
             {formatUsd(claim.settlementAmountInUsd!)} USD
           </div>
           <div className={styles.actionPanel}>
@@ -261,11 +269,11 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.mediator}>
+          <p className={styles.mediator} data-testid="actor">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
           <div className={styles.actionMainInfo}>
-            <div className={styles.approved}>
+            <div className={styles.approved} data-testid="status">
               <CheckIcon aria-hidden />
               Settled
             </div>
@@ -292,11 +300,13 @@ export default function ClaimActions(props: Props) {
         if (dispute?.appealedBy) {
           return (
             <div className={styles.actionSection}>
-              <p className={styles.arbitrator}>
+              <p className={styles.arbitrator} data-testid="actor">
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
-              <div className={styles.actionMainInfo}>Evaluating</div>
+              <div className={styles.actionMainInfo} data-testid="status">
+                Evaluating
+              </div>
               {dispute.appealedBy === claim.claimant ? (
                 <p className={styles.actionMessage}>
                   You appealed Kleros’s ruling. Kleros jurors are currently evaluating your claim
@@ -312,11 +322,13 @@ export default function ClaimActions(props: Props) {
 
         return (
           <div className={styles.actionSection}>
-            <p className={styles.arbitrator}>
+            <p className={styles.arbitrator} data-testid="actor">
               <KlerosIcon aria-hidden />
               Kleros
             </p>
-            <div className={styles.actionMainInfo}>Evaluating</div>
+            <div className={styles.actionMainInfo} data-testid="status">
+              Evaluating
+            </div>
             <p className={styles.actionMessage}>
               The claim was escalated to Kleros. Kleros jurors are currently evaluating your claim
             </p>
@@ -329,12 +341,14 @@ export default function ClaimActions(props: Props) {
           return (
             <div className={styles.actionSection}>
               {dispute.period === 'Appeal' && <h5 style={{ marginBottom: 40 }}>Appeal Period</h5>}
-              <p className={styles.arbitrator}>
+              <p className={styles.arbitrator} data-testid="actor">
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
-              <div className={styles.actionMainInfo} data-testid="status-message">
-                <div className={globalStyles.primaryColor}>Accepted</div>
+              <div className={styles.actionMainInfo}>
+                <div className={globalStyles.primaryColor} data-testid="status">
+                  Accepted
+                </div>
                 {formatUsd(claim.claimAmountInUsd)} USD
               </div>
               {dispute.period === 'Appeal' && (
@@ -356,12 +370,14 @@ export default function ClaimActions(props: Props) {
           return (
             <div className={styles.actionSection}>
               {dispute.period === 'Appeal' && <h5 style={{ marginBottom: 40 }}>Appeal Period</h5>}
-              <p className={styles.arbitrator}>
+              <p className={styles.arbitrator} data-testid="actor">
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
-              <div className={styles.actionMainInfo} data-testid="status-message">
-                <div className={globalStyles.primaryColor}>Accepted Settlement</div>
+              <div className={styles.actionMainInfo}>
+                <div className={globalStyles.primaryColor} data-testid="status">
+                  Accepted Settlement
+                </div>
                 {formatUsd(claim.settlementAmountInUsd!)} USD
               </div>
               {dispute.period === 'Appeal' && (
@@ -398,12 +414,14 @@ export default function ClaimActions(props: Props) {
           return (
             <div className={styles.actionSection}>
               {dispute.period === 'Appeal' && <h5 style={{ marginBottom: 40 }}>Appeal Period</h5>}
-              <p className={styles.arbitrator}>
+              <p className={styles.arbitrator} data-testid="actor">
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
               <div className={styles.actionMainInfo}>
-                <span className={globalStyles.primaryColor}>Rejected</span>
+                <span className={globalStyles.primaryColor} data-testid="status">
+                  Rejected
+                </span>
               </div>
               {dispute.period === 'Appeal' && (
                 <>
@@ -421,7 +439,7 @@ export default function ClaimActions(props: Props) {
                     </Modal>
                   </div>
                   <p className={styles.actionMessage}>
-                    During this appeal period you have the opportunity to appeal Kleros’s ruling
+                    During this appeal period you and the API3 Mediators have the opportunity to appeal Kleros’s ruling
                   </p>
                 </>
               )}
@@ -438,12 +456,12 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.arbitrator}>
+          <p className={styles.arbitrator} data-testid="actor">
             <KlerosIcon aria-hidden />
             Kleros
           </p>
-          <div className={styles.actionMainInfo} data-testid="status-message">
-            <div className={styles.approved}>
+          <div className={styles.actionMainInfo}>
+            <div className={styles.approved} data-testid="status">
               <CheckIcon aria-hidden />
               Accepted
             </div>
@@ -471,12 +489,12 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.arbitrator}>
+          <p className={styles.arbitrator} data-testid="actor">
             <KlerosIcon aria-hidden />
             Kleros
           </p>
-          <div className={styles.actionMainInfo} data-testid="status-message">
-            <div className={styles.approved}>
+          <div className={styles.actionMainInfo}>
+            <div className={styles.approved} data-testid="status">
               <CheckIcon aria-hidden />
               Settled
             </div>
@@ -501,12 +519,12 @@ export default function ClaimActions(props: Props) {
     case 'DisputeResolvedWithoutPayout':
       return (
         <div className={styles.actionSection}>
-          <p className={styles.arbitrator}>
+          <p className={styles.arbitrator} data-testid="actor">
             <KlerosIcon aria-hidden />
             Kleros
           </p>
           <div className={styles.actionMainInfo}>
-            <span className={styles.rejected}>
+            <span className={styles.rejected} data-testid="status">
               <CloseIcon aria-hidden />
               Rejected
             </span>

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -174,8 +174,10 @@ export default function ClaimActions(props: Props) {
           <p className={styles.mediator} data-testid="actor">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
-          <div className={styles.actionMainInfo} data-testid="status">
-            Evaluating
+          <div className={styles.actionMainInfo}>
+            <span className={globalStyles.primaryColor} data-testid="status">
+              Evaluating
+            </span>
           </div>
           <p className={styles.actionMessage}>API3 Mediators are currently evaluating your claim</p>
         </div>
@@ -195,7 +197,9 @@ export default function ClaimActions(props: Props) {
               <CheckIcon aria-hidden />
               Accepted
             </div>
-            <div data-testid="usd-amount">{formatUsd(payout.amountInUsd)} USD</div>
+            <div className={styles.usdAmount} data-testid="usd-amount">
+              {formatUsd(payout.amountInUsd)} USD
+            </div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
           <p className={styles.actionMessage}>All done! The claim payout has been accepted.</p>
@@ -238,7 +242,9 @@ export default function ClaimActions(props: Props) {
             <div className={globalStyles.primaryColor} data-testid="status">
               Offered Settlement
             </div>
-            <div data-testid="usd-amount">{formatUsd(claim.settlementAmountInUsd!)} USD</div>
+            <div className={styles.usdAmount} data-testid="usd-amount">
+              {formatUsd(claim.settlementAmountInUsd!)} USD
+            </div>
           </div>
           <div className={styles.actionPanel}>
             <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('escalate')}>
@@ -277,7 +283,9 @@ export default function ClaimActions(props: Props) {
               <CheckIcon aria-hidden />
               Settled
             </div>
-            <div data-testid="usd-amount">{formatUsd(payout.amountInUsd)} USD</div>
+            <div className={styles.usdAmount} data-testid="usd-amount">
+              {formatUsd(payout.amountInUsd)} USD
+            </div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
           <p className={styles.actionMessage}>All done! The settlement was accepted and paid out.</p>
@@ -304,8 +312,10 @@ export default function ClaimActions(props: Props) {
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
-              <div className={styles.actionMainInfo} data-testid="status">
-                Evaluating
+              <div className={styles.actionMainInfo}>
+                <span className={globalStyles.primaryColor} data-testid="status">
+                  Evaluating
+                </span>
               </div>
               {dispute.appealedBy === claim.claimant ? (
                 <p className={styles.actionMessage}>
@@ -326,8 +336,10 @@ export default function ClaimActions(props: Props) {
               <KlerosIcon aria-hidden />
               Kleros
             </p>
-            <div className={styles.actionMainInfo} data-testid="status">
-              Evaluating
+            <div className={styles.actionMainInfo}>
+              <span className={globalStyles.primaryColor} data-testid="status">
+                Evaluating
+              </span>
             </div>
             <p className={styles.actionMessage}>
               The claim was escalated to Kleros. Kleros jurors are currently evaluating your claim
@@ -349,7 +361,9 @@ export default function ClaimActions(props: Props) {
                 <div className={globalStyles.primaryColor} data-testid="status">
                   Accepted
                 </div>
-                <div data-testid="usd-amount">{formatUsd(claim.claimAmountInUsd)} USD</div>
+                <div className={styles.usdAmount} data-testid="usd-amount">
+                  {formatUsd(claim.claimAmountInUsd)} USD
+                </div>
               </div>
               {dispute.period === 'Appeal' && (
                 <p className={styles.actionMessage}>
@@ -378,7 +392,9 @@ export default function ClaimActions(props: Props) {
                 <div className={globalStyles.primaryColor} data-testid="status">
                   Accepted Settlement
                 </div>
-                <div data-testid="usd-amount">{formatUsd(claim.settlementAmountInUsd!)} USD</div>
+                <div className={styles.usdAmount} data-testid="usd-amount">
+                  {formatUsd(claim.settlementAmountInUsd!)} USD
+                </div>
               </div>
               {dispute.period === 'Appeal' && (
                 <>
@@ -465,7 +481,9 @@ export default function ClaimActions(props: Props) {
               <CheckIcon aria-hidden />
               Accepted
             </div>
-            <div data-testid="usd-amount">{formatUsd(payout.amountInUsd)} USD</div>
+            <div className={styles.usdAmount} data-testid="usd-amount">
+              {formatUsd(payout.amountInUsd)} USD
+            </div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
           <p className={styles.actionMessage}>All done! The claim payout has been accepted.</p>
@@ -498,7 +516,9 @@ export default function ClaimActions(props: Props) {
               <CheckIcon aria-hidden />
               Settled
             </div>
-            <div data-testid="usd-amount">{formatUsd(payout.amountInUsd)} USD</div>
+            <div className={styles.usdAmount} data-testid="usd-amount">
+              {formatUsd(payout.amountInUsd)} USD
+            </div>
             <PayoutAmount claim={claim} payout={props.payout!} />
           </div>
           <p className={styles.actionMessage}>All done! The settlement was accepted and paid out.</p>

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -191,11 +191,11 @@ export default function ClaimActions(props: Props) {
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
           <div className={styles.actionMainInfo}>
-            <span className={styles.approved} data-testid="status">
+            <div className={styles.approved} data-testid="status">
               <CheckIcon aria-hidden />
               Accepted
-            </span>
-            <div>{formatUsd(payout.amountInUsd)} USD</div>
+            </div>
+            <div data-testid="usd-amount">{formatUsd(payout.amountInUsd)} USD</div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
           <p className={styles.actionMessage}>All done! The claim payout has been accepted.</p>
@@ -238,7 +238,7 @@ export default function ClaimActions(props: Props) {
             <div className={globalStyles.primaryColor} data-testid="status">
               Offered Settlement
             </div>
-            {formatUsd(claim.settlementAmountInUsd!)} USD
+            <div data-testid="usd-amount">{formatUsd(claim.settlementAmountInUsd!)} USD</div>
           </div>
           <div className={styles.actionPanel}>
             <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('escalate')}>
@@ -277,7 +277,7 @@ export default function ClaimActions(props: Props) {
               <CheckIcon aria-hidden />
               Settled
             </div>
-            {formatUsd(payout.amountInUsd)} USD
+            <div data-testid="usd-amount">{formatUsd(payout.amountInUsd)} USD</div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
           <p className={styles.actionMessage}>All done! The settlement was accepted and paid out.</p>
@@ -340,7 +340,7 @@ export default function ClaimActions(props: Props) {
         case 'PayClaim':
           return (
             <div className={styles.actionSection}>
-              {dispute.period === 'Appeal' && <h5 style={{ marginBottom: 40 }}>Appeal Period</h5>}
+              {dispute.period === 'Appeal' && <h5 className={styles.heading}>Appeal Period</h5>}
               <p className={styles.arbitrator} data-testid="actor">
                 <KlerosIcon aria-hidden />
                 Kleros
@@ -349,7 +349,7 @@ export default function ClaimActions(props: Props) {
                 <div className={globalStyles.primaryColor} data-testid="status">
                   Accepted
                 </div>
-                {formatUsd(claim.claimAmountInUsd)} USD
+                <div data-testid="usd-amount">{formatUsd(claim.claimAmountInUsd)} USD</div>
               </div>
               {dispute.period === 'Appeal' && (
                 <p className={styles.actionMessage}>
@@ -369,7 +369,7 @@ export default function ClaimActions(props: Props) {
         case 'PaySettlement':
           return (
             <div className={styles.actionSection}>
-              {dispute.period === 'Appeal' && <h5 style={{ marginBottom: 40 }}>Appeal Period</h5>}
+              {dispute.period === 'Appeal' && <h5 className={styles.heading}>Appeal Period</h5>}
               <p className={styles.arbitrator} data-testid="actor">
                 <KlerosIcon aria-hidden />
                 Kleros
@@ -378,7 +378,7 @@ export default function ClaimActions(props: Props) {
                 <div className={globalStyles.primaryColor} data-testid="status">
                   Accepted Settlement
                 </div>
-                {formatUsd(claim.settlementAmountInUsd!)} USD
+                <div data-testid="usd-amount">{formatUsd(claim.settlementAmountInUsd!)} USD</div>
               </div>
               {dispute.period === 'Appeal' && (
                 <>
@@ -413,7 +413,7 @@ export default function ClaimActions(props: Props) {
         case 'DoNotPay':
           return (
             <div className={styles.actionSection}>
-              {dispute.period === 'Appeal' && <h5 style={{ marginBottom: 40 }}>Appeal Period</h5>}
+              {dispute.period === 'Appeal' && <h5 className={styles.heading}>Appeal Period</h5>}
               <p className={styles.arbitrator} data-testid="actor">
                 <KlerosIcon aria-hidden />
                 Kleros
@@ -465,7 +465,7 @@ export default function ClaimActions(props: Props) {
               <CheckIcon aria-hidden />
               Accepted
             </div>
-            {formatUsd(payout.amountInUsd)} USD
+            <div data-testid="usd-amount">{formatUsd(payout.amountInUsd)} USD</div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
           <p className={styles.actionMessage}>All done! The claim payout has been accepted.</p>
@@ -498,7 +498,7 @@ export default function ClaimActions(props: Props) {
               <CheckIcon aria-hidden />
               Settled
             </div>
-            {formatUsd(payout.amountInUsd)} USD
+            <div data-testid="usd-amount">{formatUsd(payout.amountInUsd)} USD</div>
             <PayoutAmount claim={claim} payout={props.payout!} />
           </div>
           <p className={styles.actionMessage}>All done! The settlement was accepted and paid out.</p>

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -122,7 +122,7 @@ export default function ClaimActions(props: Props) {
         if (isPastNewDeadline) {
           return (
             <div className={styles.actionSection}>
-              <p className={styles.mediator} data-testid="actor">
+              <p className={styles.mediator} data-testid="status-prefix">
                 <Api3Icon aria-hidden /> API3 Mediators
               </p>
               <div className={styles.actionMainInfo}>
@@ -142,7 +142,7 @@ export default function ClaimActions(props: Props) {
         const disableEscalate = status === 'submitting' || status === 'submitted';
         return (
           <div className={styles.actionSection}>
-            <p className={styles.mediator} data-testid="actor">
+            <p className={styles.mediator} data-testid="status-prefix">
               <Api3Icon aria-hidden /> API3 Mediators
             </p>
             <div className={styles.actionMainInfo}>
@@ -171,7 +171,7 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.mediator} data-testid="actor">
+          <p className={styles.mediator} data-testid="status-prefix">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
           <div className={styles.actionMainInfo}>
@@ -189,7 +189,7 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.mediator} data-testid="actor">
+          <p className={styles.mediator} data-testid="status-prefix">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
           <div className={styles.actionMainInfo}>
@@ -202,17 +202,19 @@ export default function ClaimActions(props: Props) {
             </div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
-          <p className={styles.actionMessage}>All done! The claim payout has been accepted.</p>
-          <ExternalLink href={getEtherscanTransactionUrl(chainId, payout.transactionHash)} className="link-primary">
-            View the transaction here
-          </ExternalLink>
-          {payout.amountInUsd.lt(amountToPayInUsd) && (
-            <p className={styles.coverageMessage}>
-              <WarningIcon aria-hidden className={styles.warningIcon} />
-              The full payout ({formatUsd(amountToPayInUsd)} USD) exceeded the remaining coverage. The remaining
-              coverage was paid out
-            </p>
-          )}
+          <div data-testid="notifications">
+            <p className={styles.actionMessage}>All done! The claim payout has been accepted.</p>
+            <ExternalLink href={getEtherscanTransactionUrl(chainId, payout.transactionHash)} className="link-primary">
+              View the transaction here
+            </ExternalLink>
+            {payout.amountInUsd.lt(amountToPayInUsd) && (
+              <p className={styles.coverageMessage}>
+                <WarningIcon aria-hidden className={styles.warningIcon} />
+                The full payout ({formatUsd(amountToPayInUsd)} USD) exceeded the remaining coverage. The remaining
+                coverage was paid out
+              </p>
+            )}
+          </div>
         </div>
       );
     }
@@ -235,7 +237,7 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.mediator} data-testid="actor">
+          <p className={styles.mediator} data-testid="status-prefix">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
           <div className={styles.actionMainInfo}>
@@ -275,7 +277,7 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.mediator} data-testid="actor">
+          <p className={styles.mediator} data-testid="status-prefix">
             <Api3Icon aria-hidden /> API3 Mediators
           </p>
           <div className={styles.actionMainInfo}>
@@ -288,17 +290,19 @@ export default function ClaimActions(props: Props) {
             </div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
-          <p className={styles.actionMessage}>All done! The settlement was accepted and paid out.</p>
-          <ExternalLink href={getEtherscanTransactionUrl(chainId, payout.transactionHash)} className="link-primary">
-            View the transaction here
-          </ExternalLink>
-          {payout.amountInUsd.lt(amountToPayInUsd) && (
-            <p className={styles.coverageMessage}>
-              <WarningIcon aria-hidden className={styles.warningIcon} />
-              The full settlement ({formatUsd(amountToPayInUsd)} USD) exceeded the remaining coverage. The remaining
-              coverage was paid out
-            </p>
-          )}
+          <div data-testid="notifications">
+            <p className={styles.actionMessage}>All done! The settlement was accepted and paid out.</p>
+            <ExternalLink href={getEtherscanTransactionUrl(chainId, payout.transactionHash)} className="link-primary">
+              View the transaction here
+            </ExternalLink>
+            {payout.amountInUsd.lt(amountToPayInUsd) && (
+              <p className={styles.coverageMessage}>
+                <WarningIcon aria-hidden className={styles.warningIcon} />
+                The full settlement ({formatUsd(amountToPayInUsd)} USD) exceeded the remaining coverage. The remaining
+                coverage was paid out
+              </p>
+            )}
+          </div>
         </div>
       );
     }
@@ -308,7 +312,7 @@ export default function ClaimActions(props: Props) {
         if (dispute?.appealedBy) {
           return (
             <div className={styles.actionSection}>
-              <p className={styles.arbitrator} data-testid="actor">
+              <p className={styles.arbitrator} data-testid="status-prefix">
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
@@ -317,22 +321,24 @@ export default function ClaimActions(props: Props) {
                   Evaluating
                 </span>
               </div>
-              {dispute.appealedBy === claim.claimant ? (
-                <p className={styles.actionMessage}>
-                  You appealed Kleros’s ruling. Kleros jurors are currently evaluating your claim
-                </p>
-              ) : (
-                <p className={styles.actionMessage}>
-                  The API3 Mediators appealed Kleros’s ruling. Kleros jurors are currently evaluating your claim
-                </p>
-              )}
+              <div data-testid="notifications">
+                {dispute.appealedBy === claim.claimant ? (
+                  <p className={styles.actionMessage}>
+                    You appealed Kleros’s ruling. Kleros jurors are currently evaluating your claim
+                  </p>
+                ) : (
+                  <p className={styles.actionMessage}>
+                    The API3 Mediators appealed Kleros’s ruling. Kleros jurors are currently evaluating your claim
+                  </p>
+                )}
+              </div>
             </div>
           );
         }
 
         return (
           <div className={styles.actionSection}>
-            <p className={styles.arbitrator} data-testid="actor">
+            <p className={styles.arbitrator} data-testid="status-prefix">
               <KlerosIcon aria-hidden />
               Kleros
             </p>
@@ -353,7 +359,7 @@ export default function ClaimActions(props: Props) {
           return (
             <div className={styles.actionSection}>
               {dispute.period === 'Appeal' && <h5 className={styles.heading}>Appeal Period</h5>}
-              <p className={styles.arbitrator} data-testid="actor">
+              <p className={styles.arbitrator} data-testid="status-prefix">
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
@@ -384,7 +390,7 @@ export default function ClaimActions(props: Props) {
           return (
             <div className={styles.actionSection}>
               {dispute.period === 'Appeal' && <h5 className={styles.heading}>Appeal Period</h5>}
-              <p className={styles.arbitrator} data-testid="actor">
+              <p className={styles.arbitrator} data-testid="status-prefix">
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
@@ -430,7 +436,7 @@ export default function ClaimActions(props: Props) {
           return (
             <div className={styles.actionSection}>
               {dispute.period === 'Appeal' && <h5 className={styles.heading}>Appeal Period</h5>}
-              <p className={styles.arbitrator} data-testid="actor">
+              <p className={styles.arbitrator} data-testid="status-prefix">
                 <KlerosIcon aria-hidden />
                 Kleros
               </p>
@@ -472,7 +478,7 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.arbitrator} data-testid="actor">
+          <p className={styles.arbitrator} data-testid="status-prefix">
             <KlerosIcon aria-hidden />
             Kleros
           </p>
@@ -486,17 +492,19 @@ export default function ClaimActions(props: Props) {
             </div>
             <PayoutAmount claim={claim} payout={payout} />
           </div>
-          <p className={styles.actionMessage}>All done! The claim payout has been accepted.</p>
-          <ExternalLink href={getEtherscanTransactionUrl(chainId, payout.transactionHash)} className="link-primary">
-            View the transaction here
-          </ExternalLink>
-          {payout.amountInUsd.lt(amountToPayInUsd) && (
-            <p className={styles.coverageMessage}>
-              <WarningIcon aria-hidden className={styles.warningIcon} />
-              The full payout ({formatUsd(amountToPayInUsd)} USD) exceeded the remaining coverage. The remaining
-              coverage was paid out
-            </p>
-          )}
+          <div data-testid="notifications">
+            <p className={styles.actionMessage}>All done! The claim payout has been accepted.</p>
+            <ExternalLink href={getEtherscanTransactionUrl(chainId, payout.transactionHash)} className="link-primary">
+              View the transaction here
+            </ExternalLink>
+            {payout.amountInUsd.lt(amountToPayInUsd) && (
+              <p className={styles.coverageMessage}>
+                <WarningIcon aria-hidden className={styles.warningIcon} />
+                The full payout ({formatUsd(amountToPayInUsd)} USD) exceeded the remaining coverage. The remaining
+                coverage was paid out
+              </p>
+            )}
+          </div>
         </div>
       );
     }
@@ -507,7 +515,7 @@ export default function ClaimActions(props: Props) {
 
       return (
         <div className={styles.actionSection}>
-          <p className={styles.arbitrator} data-testid="actor">
+          <p className={styles.arbitrator} data-testid="status-prefix">
             <KlerosIcon aria-hidden />
             Kleros
           </p>
@@ -521,17 +529,19 @@ export default function ClaimActions(props: Props) {
             </div>
             <PayoutAmount claim={claim} payout={props.payout!} />
           </div>
-          <p className={styles.actionMessage}>All done! The settlement was accepted and paid out.</p>
-          <ExternalLink href={getEtherscanTransactionUrl(chainId, payout.transactionHash)} className="link-primary">
-            View the transaction here
-          </ExternalLink>
-          {payout.amountInUsd.lt(amountToPayInUsd) && (
-            <p className={styles.coverageMessage}>
-              <WarningIcon aria-hidden className={styles.warningIcon} />
-              The full settlement ({formatUsd(amountToPayInUsd)} USD) exceeded the remaining coverage. The remaining
-              coverage was paid out
-            </p>
-          )}
+          <div data-testid="notifications">
+            <p className={styles.actionMessage}>All done! The settlement was accepted and paid out.</p>
+            <ExternalLink href={getEtherscanTransactionUrl(chainId, payout.transactionHash)} className="link-primary">
+              View the transaction here
+            </ExternalLink>
+            {payout.amountInUsd.lt(amountToPayInUsd) && (
+              <p className={styles.coverageMessage}>
+                <WarningIcon aria-hidden className={styles.warningIcon} />
+                The full settlement ({formatUsd(amountToPayInUsd)} USD) exceeded the remaining coverage. The remaining
+                coverage was paid out
+              </p>
+            )}
+          </div>
         </div>
       );
     }
@@ -539,7 +549,7 @@ export default function ClaimActions(props: Props) {
     case 'DisputeResolvedWithoutPayout':
       return (
         <div className={styles.actionSection}>
-          <p className={styles.arbitrator} data-testid="actor">
+          <p className={styles.arbitrator} data-testid="status-prefix">
             <KlerosIcon aria-hidden />
             Kleros
           </p>

--- a/src/pages/claim-details/claim-details.module.scss
+++ b/src/pages/claim-details/claim-details.module.scss
@@ -27,6 +27,16 @@
   }
 }
 
+.heading {
+  font-size: $heading-5;
+  line-height: $lh-heading-5;
+
+  @media (min-width: $min-sm) {
+    font-size: $heading-4;
+    line-height: $lh-heading-4;
+  }
+}
+
 .detailsSection {
   margin: 0 2 * $space-xl 2 * $space-xl;
 

--- a/src/pages/claim-details/claim-details.tsx
+++ b/src/pages/claim-details/claim-details.tsx
@@ -52,7 +52,7 @@ export default function ClaimDetails() {
   return (
     <ClaimDetailsLayout claimId={claimId}>
       <div className={styles.detailsHeader}>
-        <h4>{claim.policy.metadata}</h4>
+        <h4 className={styles.heading}>{claim.policy.metadata}</h4>
         {deadline && <Timer size="large" deadline={deadline} onDeadlineExceeded={forceUpdate} showDeadline />}
       </div>
       <ClaimActions key={`${claim.status}-${claim.dispute?.status}`} claim={claim} payout={payout} />

--- a/src/pages/claim-details/claim-details.tsx
+++ b/src/pages/claim-details/claim-details.tsx
@@ -55,7 +55,7 @@ export default function ClaimDetails() {
         <h4>{claim.policy.metadata}</h4>
         {deadline && <Timer size="large" deadline={deadline} onDeadlineExceeded={forceUpdate} showDeadline />}
       </div>
-      <ClaimActions key={claim.status} claim={claim} payout={payout} />
+      <ClaimActions key={`${claim.status}-${claim.dispute?.status}`} claim={claim} payout={payout} />
       <BorderedBox
         noMobileBorders
         header={

--- a/src/pages/claim-details/payout-amount.module.scss
+++ b/src/pages/claim-details/payout-amount.module.scss
@@ -3,9 +3,8 @@
 .payoutAmount {
   display: flex;
   align-items: center;
-  color: $tertiary-color;
   font-size: 20px;
-  font-weight: 400;
+  font-weight: 300;
 }
 
 .helpButton {

--- a/src/pages/claim-details/payout-amount.module.scss
+++ b/src/pages/claim-details/payout-amount.module.scss
@@ -3,6 +3,7 @@
 .payoutAmount {
   display: flex;
   align-items: center;
+  justify-content: center;
   font-size: 20px;
   font-weight: 300;
 }

--- a/src/pages/claim-details/payout-amount.tsx
+++ b/src/pages/claim-details/payout-amount.tsx
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import { Tooltip } from '../../components/tooltip';
-import { formatApi3, formatUsd, images } from '../../utils';
+import { formatApi3, images } from '../../utils';
 import { Claim, ClaimPayout } from '../../chain-data';
 import styles from './payout-amount.module.scss';
 
@@ -11,16 +11,6 @@ interface Props {
 
 export default function PayoutAmount(props: Props) {
   const { claim, payout } = props;
-
-  const getAmountToPayInUsd = () => {
-    switch (claim.status) {
-      case 'SettlementAccepted':
-      case 'DisputeResolvedWithSettlementPayout':
-        return claim.settlementAmountInUsd!;
-      default:
-        return claim.claimAmountInUsd;
-    }
-  };
 
   const getActionDescription = () => {
     switch (claim.status) {
@@ -35,13 +25,7 @@ export default function PayoutAmount(props: Props) {
 
   const renderTooltip = () => {
     const formattedDate = format(claim.statusUpdatedAt, 'dd MMM yyyy HH:mm');
-
-    return payout.amountInUsd.lt(getAmountToPayInUsd()) ? (
-      <p>
-        The API3 amount is equivalent to the service coverage that remained (<b>${formatUsd(payout.amountInUsd)} USD</b>
-        ) at the time {getActionDescription()} ({formattedDate})
-      </p>
-    ) : (
+    return (
       <p>
         The API3 amount is equivalent to the USD amount at the time {getActionDescription()} ({formattedDate})
       </p>

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -132,9 +132,9 @@ export const transactionMessages: { [key in TransactionType]: PendingTransaction
     error: 'Failed to submit new claim. Please try again.',
   },
   'accept-claim-settlement': {
-    start: 'Accepting counter offer...',
-    success: 'Success! Counter offer has been accepted.',
-    error: 'Failed to accept counter. Please try again.',
+    start: 'Accepting settlement...',
+    success: 'Success! Claim has been settled.',
+    error: 'Failed to accept settlement. Please try again.',
   },
   'escalate-claim-to-arbitrator': {
     start: 'Escalating to Kleros...',


### PR DESCRIPTION
### What does this change?
- it aligns all the claim states on the Claim Details page with the latest designs (mostly wording changes)
- shows the payout USD amount (potentially clipped) at the top instead of the claim/settlement amount
- shows a notification/warning on the page when the payout amount exceeded the remaining coverage (a similar message was removed from the payout amount tooltip)
- shows a "Timed Out" status when we are past the deadline to escalate/accept a proposed settlement
- indicates when we are in the appeal period
- minor styling tweaks to align with the initial designs from Entrecasa/Leandro (expect some more tweaks to come)

### Screenshots
(Not an exhaustive list)
<img width="862" alt="Screenshot 2022-10-17 at 14 52 27" src="https://user-images.githubusercontent.com/747979/196187726-2ff97cce-aeee-4449-a7b2-2ba06d398f7e.png">

<img width="863" alt="Screenshot 2022-10-17 at 14 58 20" src="https://user-images.githubusercontent.com/747979/196187802-536fad4f-990d-499a-9b4a-3082f38afa87.png">
<img width="836" alt="Screenshot 2022-10-17 at 14 52 00" src="https://user-images.githubusercontent.com/747979/196187748-9cdc5710-be39-42e4-a1a1-09bba4bb27bc.png">
<img width="846" alt="Screenshot 2022-10-17 at 15 22 41" src="https://user-images.githubusercontent.com/747979/196188294-f6eaf732-24c3-49a1-a537-916701ec5da4.png">
<img width="858" alt="Screenshot 2022-10-17 at 14 53 19" src="https://user-images.githubusercontent.com/747979/196188670-d4ccd036-20cf-4717-a42a-63a499001d45.png">
<img width="856" alt="Screenshot 2022-10-17 at 15 25 44" src="https://user-images.githubusercontent.com/747979/196188971-22b591ce-6e81-47a1-8a83-0394be18d3d0.png">

<img width="369" alt="Screenshot 2022-10-17 at 14 55 13" src="https://user-images.githubusercontent.com/747979/196189157-04153c29-2528-43bd-be00-82f005ff5ed9.png">
