### PR TITLE
DAO-190 Confirmation modals for accepting settlement and executing payout

### DIFF
--- a/src/pages/claim-details/claim-actions.module.scss
+++ b/src/pages/claim-details/claim-actions.module.scss
@@ -67,13 +67,14 @@
 }
 
 .actionPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   margin-bottom: $space-md;
-  & > * {
-    margin-right: $space-xl;
-  }
 
-  & > *:last-child {
-    margin-right: 0;
+  @media (min-width: $min-sm) {
+    flex-direction: row;
+    gap: $space-xl;
   }
 }
 

--- a/src/pages/claim-details/claim-actions.tsx
+++ b/src/pages/claim-details/claim-actions.tsx
@@ -8,7 +8,7 @@ import CloseIcon from '../../components/icons/close-icon';
 import Api3Icon from '../../components/icons/api3-icon';
 import KlerosIcon from '../../components/icons/kleros-icon';
 import WarningIcon from '../../components/icons/warning-icon';
-import { AppealConfirmation, EscalateConfirmation } from './confirmations';
+import { EscalateConfirmation, SettlementConfirmation, AppealConfirmation, PayoutConfirmation } from './confirmations';
 import PayoutAmount from './payout-amount';
 import { Claim, ClaimPayout, useChainData } from '../../chain-data';
 import { formatUsd, handleTransactionError } from '../../utils';
@@ -30,7 +30,7 @@ export default function ClaimActions(props: Props) {
   const claimsManager = useClaimsManager()!;
   const arbitratorProxy = useArbitratorProxy()!;
 
-  const [modalToShow, setModalToShow] = useState<'escalate' | 'appeal' | null>(null);
+  const [modalToShow, setModalToShow] = useState<'escalate' | 'settlement' | 'appeal' | 'payout' | null>(null);
   const [status, setStatus] = useState<'idle' | 'submitting' | 'submitted' | 'failed'>('idle');
 
   const isPastDeadline = claim.deadline ? isAfter(new Date(), claim.deadline) : false;
@@ -46,6 +46,7 @@ export default function ClaimActions(props: Props) {
         transactions: [...transactions, { type: 'accept-claim-settlement', tx }],
       });
       setStatus('submitted');
+      setModalToShow(null);
     } else {
       setStatus('failed');
     }
@@ -105,6 +106,7 @@ export default function ClaimActions(props: Props) {
         transactions: [...transactions, { type: 'execute-claim-payout', tx }],
       });
       setStatus('submitted');
+      setModalToShow(null);
     } else {
       setStatus('failed');
     }
@@ -156,7 +158,7 @@ export default function ClaimActions(props: Props) {
               </Button>
               <Modal open={modalToShow === 'escalate'} onClose={handleModalClose}>
                 <EscalateConfirmation
-                  disableActions={disableEscalate}
+                  disableAction={disableEscalate}
                   onConfirm={handleEscalateToArbitrator}
                   onCancel={handleModalClose}
                 />
@@ -252,13 +254,20 @@ export default function ClaimActions(props: Props) {
             <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('escalate')}>
               Escalate to Kleros
             </Button>
-            <Button variant="secondary" disabled={disableActions} onClick={handleAcceptSettlement}>
+            <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('settlement')}>
               Accept Settlement
             </Button>
             <Modal open={modalToShow === 'escalate'} onClose={handleModalClose}>
               <EscalateConfirmation
-                disableActions={disableActions}
+                disableAction={disableActions}
                 onConfirm={handleEscalateToArbitrator}
+                onCancel={handleModalClose}
+              />
+            </Modal>
+            <Modal open={modalToShow === 'settlement'} onClose={handleModalClose}>
+              <SettlementConfirmation
+                disableAction={disableActions}
+                onConfirm={handleAcceptSettlement}
                 onCancel={handleModalClose}
               />
             </Modal>
@@ -378,9 +387,16 @@ export default function ClaimActions(props: Props) {
               )}
               {dispute.period === 'Execution' && (
                 <div className={styles.actionPanel}>
-                  <Button variant="secondary" disabled={disableActions} onClick={handleExecutePayout}>
+                  <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('payout')}>
                     Execute Payout
                   </Button>
+                  <Modal open={modalToShow === 'payout'} onClose={handleModalClose}>
+                    <PayoutConfirmation
+                      disableAction={disableActions}
+                      onConfirm={handleExecutePayout}
+                      onCancel={handleModalClose}
+                    />
+                  </Modal>
                 </div>
               )}
             </div>
@@ -411,7 +427,7 @@ export default function ClaimActions(props: Props) {
                     <Modal open={modalToShow === 'appeal'} onClose={handleModalClose}>
                       <AppealConfirmation
                         disputeId={claim.dispute!.id}
-                        disableActions={disableActions}
+                        disableAction={disableActions}
                         onConfirm={handleAppeal}
                         onCancel={handleModalClose}
                       />
@@ -424,9 +440,16 @@ export default function ClaimActions(props: Props) {
               )}
               {dispute.period === 'Execution' && (
                 <div className={styles.actionPanel}>
-                  <Button variant="secondary" disabled={disableActions} onClick={handleExecutePayout}>
+                  <Button variant="secondary" disabled={disableActions} onClick={() => setModalToShow('payout')}>
                     Execute Payout
                   </Button>
+                  <Modal open={modalToShow === 'payout'} onClose={handleModalClose}>
+                    <PayoutConfirmation
+                      disableAction={disableActions}
+                      onConfirm={handleExecutePayout}
+                      onCancel={handleModalClose}
+                    />
+                  </Modal>
                 </div>
               )}
             </div>
@@ -454,7 +477,7 @@ export default function ClaimActions(props: Props) {
                     <Modal open={modalToShow === 'appeal'} onClose={handleModalClose}>
                       <AppealConfirmation
                         disputeId={claim.dispute!.id}
-                        disableActions={disableActions}
+                        disableAction={disableActions}
                         onConfirm={handleAppeal}
                         onCancel={handleModalClose}
                       />

--- a/src/pages/claim-details/confirmations.module.scss
+++ b/src/pages/claim-details/confirmations.module.scss
@@ -25,7 +25,6 @@
   flex-direction: column;
   gap: 2.5rem;
   width: 100%;
-  max-width: 320px;
 
   button {
     font-weight: 500;
@@ -34,9 +33,7 @@
   @media (min-width: $min-sm) {
     flex-direction: row;
     align-items: center;
-    gap: 1rem;
-    button {
-      width: 50%;
-    }
+    justify-content: center;
+    gap: 3rem;
   }
 }

--- a/src/pages/claim-details/confirmations.tsx
+++ b/src/pages/claim-details/confirmations.tsx
@@ -165,11 +165,11 @@ interface SettlementConfirmationProps {
 export function SettlementConfirmation(props: SettlementConfirmationProps) {
   return (
     <>
-      <ModalHeader>API3 Conversion</ModalHeader>
+      <ModalHeader>You will be paid in API3 tokens</ModalHeader>
       <div className={styles.body}>
         <p className={styles.info}>
-          The USD amount will be converted into API3 tokens and transferred from the API3 token staking pool to the
-          claimant’s address when you accept the settlement.{' '}
+          The USD amount will be converted into API3 tokens and transferred from the API3 staking pool to the claimant’s
+          address when you accept the settlement.{' '}
           <span className={globalStyles.primaryColor}>The process is permissionless and automatic.</span>
         </p>
       </div>
@@ -196,11 +196,11 @@ interface PayoutConfirmationProps {
 export function PayoutConfirmation(props: PayoutConfirmationProps) {
   return (
     <>
-      <ModalHeader>API3 Conversion</ModalHeader>
+      <ModalHeader>You will be paid in API3 tokens</ModalHeader>
       <div className={styles.body}>
         <p className={styles.info}>
-          The USD amount will be converted into API3 tokens and transferred from the API3 token staking pool to the
-          claimant’s address when you execute the payout.{' '}
+          The USD amount will be converted into API3 tokens and transferred from the API3 staking pool to the claimant’s
+          address when you execute the payout.{' '}
           <span className={globalStyles.primaryColor}>The process is permissionless and automatic.</span>
         </p>
       </div>

--- a/src/pages/claim-details/confirmations.tsx
+++ b/src/pages/claim-details/confirmations.tsx
@@ -8,10 +8,11 @@ import Skeleton from '../../components/skeleton';
 import { notifications } from '../../components/notifications';
 import { formatEther, messages } from '../../utils';
 import { useArbitratorProxy } from '../../contracts';
+import globalStyles from '../../styles/global-styles.module.scss';
 import styles from './confirmations.module.scss';
 
 interface EscalateConfirmationProps {
-  disableActions: boolean;
+  disableAction: boolean;
   onConfirm: (cost: BigNumber) => void;
   onCancel: () => void;
 }
@@ -71,7 +72,7 @@ export function EscalateConfirmation(props: EscalateConfirmationProps) {
           <Button
             variant="primary"
             size="large"
-            disabled={!cost || props.disableActions}
+            disabled={!cost || props.disableAction}
             onClick={() => props.onConfirm(cost!)}
           >
             Escalate
@@ -84,7 +85,7 @@ export function EscalateConfirmation(props: EscalateConfirmationProps) {
 
 interface AppealConfirmationProps {
   disputeId: string;
-  disableActions: boolean;
+  disableAction: boolean;
   onConfirm: (cost: BigNumber) => void;
   onCancel: () => void;
 }
@@ -144,10 +145,72 @@ export function AppealConfirmation(props: AppealConfirmationProps) {
           <Button
             variant="primary"
             size="large"
-            disabled={!cost || props.disableActions}
+            disabled={!cost || props.disableAction}
             onClick={() => props.onConfirm(cost!)}
           >
             Appeal
+          </Button>
+        </div>
+      </ModalFooter>
+    </>
+  );
+}
+
+interface SettlementConfirmationProps {
+  disableAction: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function SettlementConfirmation(props: SettlementConfirmationProps) {
+  return (
+    <>
+      <ModalHeader>API3 Conversion</ModalHeader>
+      <div className={styles.body}>
+        <p className={styles.info}>
+          The USD amount will be converted into API3 tokens and transferred from the API3 token staking pool to the
+          claimant’s address when you accept the settlement.{' '}
+          <span className={globalStyles.primaryColor}>The process is permissionless and automatic.</span>
+        </p>
+      </div>
+      <ModalFooter>
+        <div className={styles.buttonRow}>
+          <Button variant="text" onClick={props.onCancel}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="large" disabled={props.disableAction} onClick={props.onConfirm}>
+            Accept Settlement
+          </Button>
+        </div>
+      </ModalFooter>
+    </>
+  );
+}
+
+interface PayoutConfirmationProps {
+  disableAction: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function PayoutConfirmation(props: PayoutConfirmationProps) {
+  return (
+    <>
+      <ModalHeader>API3 Conversion</ModalHeader>
+      <div className={styles.body}>
+        <p className={styles.info}>
+          The USD amount will be converted into API3 tokens and transferred from the API3 token staking pool to the
+          claimant’s address when you execute the payout.{' '}
+          <span className={globalStyles.primaryColor}>The process is permissionless and automatic.</span>
+        </p>
+      </div>
+      <ModalFooter>
+        <div className={styles.buttonRow}>
+          <Button variant="text" onClick={props.onCancel}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="large" disabled={props.disableAction} onClick={props.onConfirm}>
+            Execute Payout
           </Button>
         </div>
       </ModalFooter>


### PR DESCRIPTION
### What does this change?
Adds a confirmation modal that informs/reminds the user that they will be paid out in API3 tokens when they accept the settlement or execute the payout.

### Screenshots
<img width="612" alt="Screenshot 2022-10-19 at 09 45 19" src="https://user-images.githubusercontent.com/747979/196636045-261a2e5a-3f7b-46b6-97ac-730621609d2d.png">
<img width="629" alt="Screenshot 2022-10-19 at 09 45 04" src="https://user-images.githubusercontent.com/747979/196636062-eb157602-a30f-41da-b9cc-2a89e754104f.png">
