### PR TITLE
Pin main branch Docker parent image to node:16-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile builds a mainnet version for API3 DAO dashboard
 
-FROM node:lts-alpine as builder
+FROM node:16-alpine as builder
 RUN apk add --update --no-cache git $([ $(arch) == "aarch64" ] && echo "python3 make g++")
 WORKDIR /usr
 RUN git clone --depth=1 --branch production https://github.com/api3dao/api3-dao-dashboard.git


### PR DESCRIPTION
Same as #353 but for the `main` branch.