### PR TITLE
DAO-218 Use USD suffix when formatting USD amounts

### DIFF
--- a/src/components/usd-input/usd-input.tsx
+++ b/src/components/usd-input/usd-input.tsx
@@ -16,8 +16,8 @@ export default function UsdInput(props: Props) {
         allowNegative={false}
         decimalScale={2}
         fixedDecimalScale
-        placeholder="$0.00"
-        prefix="$"
+        placeholder="0 USD"
+        suffix=" USD"
         {...props}
         onValueChange={(update) => props.onValueChange?.(update.value)}
       />

--- a/src/pages/claim-details/claim-details.tsx
+++ b/src/pages/claim-details/claim-details.tsx
@@ -110,7 +110,7 @@ function ClaimSummary(props: ClaimSummaryProps) {
       </div>
       <div className={styles.detailsItem}>
         <p className={globalStyles.bold}>Claim Amount</p>
-        <p className={globalStyles.secondaryColor}>${formatUsd(claim.claimAmountInUsd)}</p>
+        <p className={globalStyles.secondaryColor}>{formatUsd(claim.claimAmountInUsd)} USD</p>
       </div>
       {claim.settlementAmountInUsd && (
         <div className={styles.detailsItem}>
@@ -126,14 +126,14 @@ function ClaimSummary(props: ClaimSummaryProps) {
               </button>
             </Tooltip>
           </p>
-          <p className={globalStyles.secondaryColor}>${formatUsd(claim.settlementAmountInUsd)}</p>
+          <p className={globalStyles.secondaryColor}>{formatUsd(claim.settlementAmountInUsd)} USD</p>
         </div>
       )}
       <div className={styles.detailsItem}>
         <p className={globalStyles.bold}>Remaining Service Coverage Amount</p>
         <div className={globalStyles.secondaryColor}>
           {policy ? (
-            <>${formatUsd(policy.remainingCoverageInUsd)}</>
+            <>{formatUsd(policy.remainingCoverageInUsd)} USD</>
           ) : policyStatus === 'failed' ? (
             '-'
           ) : (

--- a/src/pages/components/policies/policy-list.tsx
+++ b/src/pages/components/policies/policy-list.tsx
@@ -44,7 +44,7 @@ export default function PolicyList(props: Props) {
                 <div className={styles.infoEntry}>
                   {policy.remainingCoverageInUsd ? (
                     <span>
-                      ${formatUsd(policy.remainingCoverageInUsd)}{' '}
+                      {formatUsd(policy.remainingCoverageInUsd)} USD{' '}
                       <span className={globalStyles.tertiaryColor}>remaining</span>
                     </span>
                   ) : (

--- a/src/pages/new-claim/new-claim-form.tsx
+++ b/src/pages/new-claim/new-claim-form.tsx
@@ -86,7 +86,7 @@ export default function NewClaimForm(props: Props) {
             <UsdInput id="amount" value={form.amount} onValueChange={(amount) => onChange({ ...form, amount })} />
           </div>
           {showMessages && messages.amount && <p className={styles.validation}>{messages.amount}</p>}
-          <p className={styles.helpText}>You can claim up to ${formatUsd(policy.remainingCoverageInUsd)}</p>
+          <p className={styles.helpText}>You can claim up to {formatUsd(policy.remainingCoverageInUsd)} USD</p>
         </li>
       </ol>
       <Acknowledgement />

--- a/src/pages/policy-details/policy-details.tsx
+++ b/src/pages/policy-details/policy-details.tsx
@@ -98,7 +98,7 @@ export default function PolicyDetails() {
             </div>
             <div className={styles.detailsItem}>
               <p className={globalStyles.bold}>Remaining Service Coverage Amount</p>
-              <p className={globalStyles.secondaryColor}>${formatUsd(policy.remainingCoverageInUsd)}</p>
+              <p className={globalStyles.secondaryColor}>{formatUsd(policy.remainingCoverageInUsd)} USD</p>
             </div>
             <div className={styles.detailsItem}>
               <p className={globalStyles.bold}>Claims Allowed From</p>

--- a/src/utils/api3-format.test.ts
+++ b/src/utils/api3-format.test.ts
@@ -45,7 +45,7 @@ test('formatApi3', () => {
 });
 
 test('formatUsd', () => {
-  expect(formatUsd).toBe(formatEther);
+  expect(formatUsd).toBe(formatAndRoundApi3);
 });
 
 test('round', () => {

--- a/src/utils/api3-format.ts
+++ b/src/utils/api3-format.ts
@@ -10,15 +10,15 @@ export const formatEther = (value: BigNumberish, commify = true) => {
 // API3 Token has the same denomination as ETH.
 export const formatApi3 = formatEther;
 
-// We store the USD amounts in the same denomination as ETH.
-export const formatUsd = formatEther;
-
 export const formatAndRoundApi3 = (tokens: BigNumberish, decimals = DEFAULT_DECIMALS) => {
   const formatted = utils.formatEther(tokens);
   // NOTE: The number of tokens is formatted by ethers first so it will fit into JS number
   // Also, ethers.commify will strip unnecessary zero decimals from end. For example, 12.00 becomes 12.0
   return utils.commify(Number.parseFloat(formatted).toFixed(decimals));
 };
+
+// We store the USD amounts in the same denomination as API3 and ETH.
+export const formatUsd = formatAndRoundApi3;
 
 export const parseEther = utils.parseEther;
 


### PR DESCRIPTION
### What does this change?
- removes the $ symbol prefix and uses a USD suffix when formatting USD amounts
- rounds the USD amount when formatting (to 2 decimals)