### PR TITLE
DAO-224 Improve page transition scrolling for mobile

### DIFF
--- a/src/pages/claim-details/claim-actions.module.scss
+++ b/src/pages/claim-details/claim-actions.module.scss
@@ -7,7 +7,7 @@
   color: $secondary-color;
   text-align: center;
   word-break: break-word;
-  margin-top: $space-xxl;
+  margin-top: 52px;
   margin-bottom: 4rem;
   padding-bottom: 4rem;
   border-bottom: 1px solid $black-line-color;
@@ -15,6 +15,10 @@
   @media (min-width: $min-sm) {
     border-bottom: none;
     padding-bottom: 0;
+  }
+
+  @media (min-width: $min-md) {
+    margin-top: $space-xxl;
   }
 }
 

--- a/src/pages/claim-details/claim-details.module.scss
+++ b/src/pages/claim-details/claim-details.module.scss
@@ -30,6 +30,7 @@
 .heading {
   font-size: $heading-5;
   line-height: $lh-heading-5;
+  margin-bottom: $space-xl;
 
   @media (min-width: $min-sm) {
     font-size: $heading-4;

--- a/src/pages/new-claim/new-claim.tsx
+++ b/src/pages/new-claim/new-claim.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useState } from 'react';
+import { ComponentProps, useState, useLayoutEffect } from 'react';
 import { useParams } from 'react-router';
 import { Link, Redirect } from 'react-router-dom';
 import { BaseLayout } from '../../components/layout';
@@ -25,6 +25,10 @@ interface Params {
 export default function NewClaim() {
   const { policyId } = useParams<Params>();
   const [step, setStep] = useState<'instructions' | 'capture' | 'confirmation'>('instructions');
+
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [step]);
 
   const { setChainData, transactions } = useChainData();
   const claimsManager = useClaimsManager();

--- a/src/pages/policy-select/policy-select.tsx
+++ b/src/pages/policy-select/policy-select.tsx
@@ -3,10 +3,11 @@ import { BaseLayout } from '../../components/layout';
 import BorderedBox from '../../components/bordered-box';
 import Policies from '../components/policies';
 import SearchForm from '../components/search-form';
-import { useQueryParams } from '../../utils';
+import { useQueryParams, useScrollToTop } from '../../utils';
 import styles from './policy-select.module.scss';
 
 export default function PolicySelect() {
+  useScrollToTop();
   const history = useHistory();
   const params = useQueryParams();
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useReducer, useRef } from 'react';
 import { useLocation } from 'react-router';
 import isEqual from 'lodash/isEqual';
 
@@ -42,7 +42,7 @@ export const useQueryParams = () => {
 
 export const useScrollToTop = () => {
   const { pathname } = useLocation();
-  useEffect(() => {
+  useLayoutEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
 };


### PR DESCRIPTION
### What does this change?
- adds a scroll to top effect when moving between the New Claim steps
- adds a scroll to top effect for the Policy Select page
- uses the `useLayoutEffect()` hook to trigger the scroll (to avoid occasional flicker of "unscrolled" content)
