### PR TITLE
Add docker build and push CI workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,37 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - production
+
+jobs:
+  docker-build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/api3-dao-dashboard
+          tags: |
+            # set latest tag for production branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'production') }}
+            type=sha
+      - name: Login to Docker Hub
+        if: ${{ github.ref == 'refs/heads/production' }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/production' }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,11 +18,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/api3-dao-dashboard
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/dao-dashboard
           tags: |
             # set latest tag for production branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'production') }}
-            type=sha
+            type=sha,prefix=,suffix=,format=long
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/production' }}
         uses: docker/login-action@v2


### PR DESCRIPTION
Closes DAO-228 and DAO-161 (the latter once the secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are saved in the repo Settings).

This workflow builds the Docker image on a push to either `main` or `production`, whereas login & push to Docker Hub occurs only on the `production` branch. The production image is tagged with both `latest` and the SHA in the form of `sha-#######`. 

I've tested this on my fork:
- `main` [Action log](https://github.com/dcroote/api3-dao-dashboard/actions/runs/3457977495/jobs/5771934237): build but no push as expected
- `production` [Action log](https://github.com/dcroote/api3-dao-dashboard/actions/runs/3458031639/jobs/5772041116): login and push to repo - you can see the [tagged images here](https://hub.docker.com/r/dcroote/api3-dao-dashboard/tags). I've tested the `latest` image works correctly for loading the dashboard & connecting a wallet.
