### PR TITLE
DAO-226 Claim list: Alternative mechanism for showing the evaluation time for API3/Kleros

### DIFF
--- a/src/chain-data/state.ts
+++ b/src/chain-data/state.ts
@@ -140,7 +140,11 @@ export interface Claim {
     ruling: ArbitratorRuling;
     period: DisputePeriod;
     periodChangedAt: Date;
-    timesPerPeriod: number[]; // One for each period except the last period (execution)
+    periodTimes: {
+      evidence: number;
+      vote: number;
+      appeal: number;
+    };
     appealedBy: null | string;
   };
   policy: { id: string; metadata: string };

--- a/src/chain-data/state.ts
+++ b/src/chain-data/state.ts
@@ -139,7 +139,7 @@ export interface Claim {
     status: DisputeStatus;
     ruling: ArbitratorRuling;
     period: DisputePeriod;
-    periodEndDate: null | Date; // The last period (execution) does not have an end date
+    periodChangedAt: Date;
     timesPerPeriod: number[]; // One for each period except the last period (execution)
     appealedBy: null | string;
   };

--- a/src/chain-data/state.ts
+++ b/src/chain-data/state.ts
@@ -140,6 +140,7 @@ export interface Claim {
     ruling: ArbitratorRuling;
     period: DisputePeriod;
     periodEndDate: null | Date; // The last period (execution) does not have an end date
+    timesPerPeriod: number[]; // One for each period except the last period (execution)
     appealedBy: null | string;
   };
   policy: { id: string; metadata: string };

--- a/src/components/icons/info-icon.tsx
+++ b/src/components/icons/info-icon.tsx
@@ -1,0 +1,13 @@
+import { ComponentProps } from 'react';
+
+export default function InfoIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg width={20} height={20} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <circle cx={10} cy={10} r={9.5} stroke="currentColor" />
+      <path
+        d="M9.363 14.076h1.274V7.531H9.363v6.545Zm.643-7.555c.439 0 .806-.341.806-.759 0-.417-.367-.762-.806-.762-.443 0-.805.345-.805.762 0 .418.362.759.805.759Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/src/components/timer/hooks.ts
+++ b/src/components/timer/hooks.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react';
+import { getDays, getHours, getMinutes, getSeconds, usePrevious } from '../../utils';
+
+interface Countdown {
+  days: string;
+  hours: string;
+  minutes: string;
+  seconds: string;
+  dateDiff: number;
+}
+
+export function useCountdown(deadline: Date, onDeadlineExceeded?: () => void) {
+  const [countdown, setCountdown] = useState<Countdown>(() => calculateCountdown(deadline));
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const countdown = calculateCountdown(deadline);
+      setCountdown(countdown);
+
+      if (countdown.dateDiff === 0) {
+        clearInterval(timer);
+      }
+    }, 1000);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [deadline]);
+
+  const callbackRef = useRef(onDeadlineExceeded);
+  useEffect(() => {
+    callbackRef.current = onDeadlineExceeded;
+  });
+
+  const { dateDiff } = countdown;
+  const previousDateDiff = usePrevious(dateDiff) || 0;
+  useEffect(() => {
+    // We trigger the callback when we have gone past the deadline (i.e. from a positive diff to a zero diff)
+    if (previousDateDiff > 0 && dateDiff === 0) {
+      callbackRef.current && callbackRef.current();
+    }
+  }, [previousDateDiff, dateDiff]);
+
+  return countdown;
+}
+
+function calculateCountdown(deadline: Date): Countdown {
+  const now = new Date().getTime();
+  const dateDiff = Math.max(deadline.getTime() - now, 0);
+
+  return {
+    days: getDays(dateDiff),
+    hours: getHours(dateDiff),
+    minutes: getMinutes(dateDiff),
+    seconds: getSeconds(dateDiff),
+    dateDiff,
+  };
+}

--- a/src/logic/claims/data.test.ts
+++ b/src/logic/claims/data.test.ts
@@ -2,7 +2,7 @@ import { calculateDeadline } from './data';
 import { addDays, addSeconds } from 'date-fns';
 
 describe('calculateDeadline', () => {
-  it('returns a deadline of 3 days for "ClaimCreated"', () => {
+  it('returns a deadline of 3 days for "ClaimCreated" status', () => {
     const statusUpdatedAt = addSeconds(new Date(), -42);
     const deadline = calculateDeadline({
       status: 'ClaimCreated',
@@ -13,7 +13,7 @@ describe('calculateDeadline', () => {
     expect(deadline).toEqual(addDays(statusUpdatedAt, 3));
   });
 
-  it('returns a deadline of 3 days for "SettlementProposed"', () => {
+  it('returns a deadline of 3 days for "SettlementProposed" status', () => {
     const statusUpdatedAt = addSeconds(new Date(), -42);
     const deadline = calculateDeadline({
       status: 'SettlementProposed',
@@ -25,7 +25,7 @@ describe('calculateDeadline', () => {
   });
 
   describe('when the dispute is in its "Evidence" period', () => {
-    it('returns the period end date with the "Vote" period added on', () => {
+    it('returns the vote period end date', () => {
       const periodChangedAt = addSeconds(new Date(), -42);
       const evidencePeriod = 3.25 * 24 * 60 * 60;
       const votePeriod = 6.75 * 24 * 60 * 60;
@@ -53,7 +53,7 @@ describe('calculateDeadline', () => {
   });
 
   describe('when the dispute is in its "Vote" period', () => {
-    it('returns the period end date', () => {
+    it('returns the vote period end date', () => {
       const periodChangedAt = addSeconds(new Date(), -42);
       const votePeriod = 6.75 * 24 * 60 * 60;
       const deadline = calculateDeadline({
@@ -80,7 +80,7 @@ describe('calculateDeadline', () => {
   });
 
   describe('when the dispute is in its "Appeal" period', () => {
-    it('returns the period end date', () => {
+    it('returns the appeal period end date', () => {
       const periodChangedAt = addSeconds(new Date(), -42);
       const appealPeriod = 4.5 * 24 * 60 * 60;
       const deadline = calculateDeadline({

--- a/src/logic/claims/data.test.ts
+++ b/src/logic/claims/data.test.ts
@@ -1,0 +1,133 @@
+import { calculateDeadline } from './data';
+import { addDays, addSeconds } from 'date-fns';
+
+describe('calculateDeadline', () => {
+  it('returns a deadline of 3 days for "ClaimCreated"', () => {
+    const statusUpdatedAt = addSeconds(new Date(), -42);
+    const deadline = calculateDeadline({
+      status: 'ClaimCreated',
+      statusUpdatedAt,
+      dispute: null,
+    });
+
+    expect(deadline).toEqual(addDays(statusUpdatedAt, 3));
+  });
+
+  it('returns a deadline of 3 days for "SettlementProposed"', () => {
+    const statusUpdatedAt = addSeconds(new Date(), -42);
+    const deadline = calculateDeadline({
+      status: 'SettlementProposed',
+      statusUpdatedAt,
+      dispute: null,
+    });
+
+    expect(deadline).toEqual(addDays(statusUpdatedAt, 3));
+  });
+
+  describe('when the dispute is in its "Evidence" period', () => {
+    it('returns the period end date with the "Vote" period added on', () => {
+      const periodChangedAt = addSeconds(new Date(), -42);
+      const evidencePeriod = 3.25 * 24 * 60 * 60;
+      const votePeriod = 6.75 * 24 * 60 * 60;
+      const deadline = calculateDeadline({
+        status: 'DisputeCreated',
+        statusUpdatedAt: addDays(new Date(), -14),
+        dispute: {
+          id: '1',
+          status: 'Waiting',
+          ruling: 'DoNotPay',
+          period: 'Evidence',
+          periodChangedAt,
+          timesPerPeriod: [
+            evidencePeriod,
+            1000, // Commit
+            votePeriod,
+            4.5 * 24 * 60 * 60, // Appeal
+          ],
+          appealedBy: null,
+        },
+      });
+
+      expect(deadline).toEqual(addSeconds(periodChangedAt, evidencePeriod + votePeriod));
+    });
+  });
+
+  describe('when the dispute is in its "Vote" period', () => {
+    it('returns the period end date', () => {
+      const periodChangedAt = addSeconds(new Date(), -42);
+      const votePeriod = 6.75 * 24 * 60 * 60;
+      const deadline = calculateDeadline({
+        status: 'DisputeCreated',
+        statusUpdatedAt: addDays(new Date(), -14),
+        dispute: {
+          id: '1',
+          status: 'Waiting',
+          ruling: 'DoNotPay',
+          period: 'Vote',
+          periodChangedAt,
+          timesPerPeriod: [
+            3.25 * 24 * 60 * 60, // Evidence
+            1000, // Commit
+            votePeriod,
+            4.5 * 24 * 60 * 60, // Appeal
+          ],
+          appealedBy: null,
+        },
+      });
+
+      expect(deadline).toEqual(addSeconds(periodChangedAt, votePeriod));
+    });
+  });
+
+  describe('when the dispute is in its "Appeal" period', () => {
+    it('returns the period end date', () => {
+      const periodChangedAt = addSeconds(new Date(), -42);
+      const appealPeriod = 4.5 * 24 * 60 * 60;
+      const deadline = calculateDeadline({
+        status: 'DisputeCreated',
+        statusUpdatedAt: addDays(new Date(), -14),
+        dispute: {
+          id: '1',
+          status: 'Appealable',
+          ruling: 'DoNotPay',
+          period: 'Appeal',
+          periodChangedAt,
+          timesPerPeriod: [
+            3.25 * 24 * 60 * 60, // Evidence
+            1000, // Commit
+            6.75 * 24 * 60 * 60, // Vote
+            appealPeriod,
+          ],
+          appealedBy: null,
+        },
+      });
+
+      expect(deadline).toEqual(addSeconds(periodChangedAt, appealPeriod));
+    });
+  });
+
+  describe('when the dispute is in its "Execution" period', () => {
+    it('returns nothing', () => {
+      const deadline = calculateDeadline({
+        status: 'DisputeCreated',
+        statusUpdatedAt: addDays(new Date(), -14),
+        dispute: {
+          id: '1',
+          status: 'Solved',
+          ruling: 'DoNotPay',
+          period: 'Execution',
+          periodChangedAt: new Date(),
+          timesPerPeriod: [
+            3.25 * 24 * 60 * 60, // Evidence
+            1000, // Commit
+            6.75 * 24 * 60 * 60, // Vote
+            4.5 * 24 * 60 * 60, // Appeal
+          ],
+          appealedBy: null,
+        },
+      });
+
+      expect(deadline).toEqual(null);
+    });
+  });
+});

--- a/src/logic/claims/data.test.ts
+++ b/src/logic/claims/data.test.ts
@@ -38,12 +38,11 @@ describe('calculateDeadline', () => {
           ruling: 'DoNotPay',
           period: 'Evidence',
           periodChangedAt,
-          timesPerPeriod: [
-            evidencePeriod,
-            1000, // Commit
-            votePeriod,
-            4.5 * 24 * 60 * 60, // Appeal
-          ],
+          periodTimes: {
+            evidence: evidencePeriod,
+            vote: votePeriod,
+            appeal: 4.5 * 24 * 60 * 60,
+          },
           appealedBy: null,
         },
       });
@@ -65,12 +64,11 @@ describe('calculateDeadline', () => {
           ruling: 'DoNotPay',
           period: 'Vote',
           periodChangedAt,
-          timesPerPeriod: [
-            3.25 * 24 * 60 * 60, // Evidence
-            1000, // Commit
-            votePeriod,
-            4.5 * 24 * 60 * 60, // Appeal
-          ],
+          periodTimes: {
+            evidence: 3.25 * 24 * 60 * 60,
+            vote: votePeriod,
+            appeal: 4.5 * 24 * 60 * 60,
+          },
           appealedBy: null,
         },
       });
@@ -92,12 +90,11 @@ describe('calculateDeadline', () => {
           ruling: 'DoNotPay',
           period: 'Appeal',
           periodChangedAt,
-          timesPerPeriod: [
-            3.25 * 24 * 60 * 60, // Evidence
-            1000, // Commit
-            6.75 * 24 * 60 * 60, // Vote
-            appealPeriod,
-          ],
+          periodTimes: {
+            evidence: 3.25 * 24 * 60 * 60,
+            vote: 6.75 * 24 * 60 * 60,
+            appeal: appealPeriod,
+          },
           appealedBy: null,
         },
       });
@@ -117,12 +114,11 @@ describe('calculateDeadline', () => {
           ruling: 'DoNotPay',
           period: 'Execution',
           periodChangedAt: new Date(),
-          timesPerPeriod: [
-            3.25 * 24 * 60 * 60, // Evidence
-            1000, // Commit
-            6.75 * 24 * 60 * 60, // Vote
-            4.5 * 24 * 60 * 60, // Appeal
-          ],
+          periodTimes: {
+            evidence: 3.25 * 24 * 60 * 60,
+            vote: 6.75 * 24 * 60 * 60,
+            appeal: 4.5 * 24 * 60 * 60,
+          },
           appealedBy: null,
         },
       });

--- a/src/logic/claims/data.ts
+++ b/src/logic/claims/data.ts
@@ -203,11 +203,11 @@ export function calculateDeadline(claim: Pick<Claim, 'status' | 'statusUpdatedAt
         case 'Evidence':
           // Kleros gives their ruling after the voting period, so we get the voting period end date by adding the vote
           // period to the evidence period (the commit period is skipped because the sub court does not have hidden votes).
-          return addSeconds(dispute.periodChangedAt, dispute.timesPerPeriod[0]! + dispute.timesPerPeriod[2]!);
+          return addSeconds(dispute.periodChangedAt, dispute.periodTimes.evidence + dispute.periodTimes.vote);
         case 'Vote':
-          return addSeconds(dispute.periodChangedAt, dispute.timesPerPeriod[2]!);
+          return addSeconds(dispute.periodChangedAt, dispute.periodTimes.vote);
         case 'Appeal':
-          return addSeconds(dispute.periodChangedAt, dispute.timesPerPeriod[3]!);
+          return addSeconds(dispute.periodChangedAt, dispute.periodTimes.appeal);
         default:
           return null;
       }
@@ -322,7 +322,11 @@ async function getDisputeContractData(contract: KlerosLiquidProxy, disputeEvents
       ruling: ArbitratorRulings[rulingCode],
       period,
       periodChangedAt: blockTimestampToDate(dispute.lastPeriodChange),
-      timesPerPeriod: subCourt.timesPerPeriod.map((time) => time.toNumber()),
+      periodTimes: {
+        evidence: subCourt.timesPerPeriod[0].toNumber(),
+        vote: subCourt.timesPerPeriod[2].toNumber(),
+        appeal: subCourt.timesPerPeriod[3].toNumber(),
+      },
       appealedBy: last(appealers) ?? null,
     };
   });

--- a/src/logic/claims/data.ts
+++ b/src/logic/claims/data.ts
@@ -201,8 +201,8 @@ export function calculateDeadline(claim: Pick<Claim, 'status' | 'statusUpdatedAt
     case 'DisputeCreated':
       switch (dispute?.period) {
         case 'Evidence':
-          // Kleros gives their ruling after the voting period, so we add the voting period to the evidence
-          // period (the commit period is skipped because the sub court does not have hidden votes).
+          // Kleros gives their ruling after the voting period, so we get the voting period end date by adding the vote
+          // period to the evidence period (the commit period is skipped because the sub court does not have hidden votes).
           return addSeconds(dispute.periodChangedAt, dispute.timesPerPeriod[0]! + dispute.timesPerPeriod[2]!);
         case 'Vote':
           return addSeconds(dispute.periodChangedAt, dispute.timesPerPeriod[2]!);

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -5,6 +5,7 @@ import { addDays, addMinutes } from 'date-fns';
 import { parseApi3, parseUsd } from '../../utils';
 
 let claim: Claim;
+const timesPerPeriod = [280800, 583200, 583200, 388800];
 
 describe('<ClaimActions />', () => {
   beforeEach(() => {
@@ -140,6 +141,7 @@ describe('<ClaimActions />', () => {
         ruling: 'DoNotPay',
         period: 'Evidence',
         periodEndDate: addDays(new Date(), 2),
+        timesPerPeriod,
         appealedBy: null,
       };
 
@@ -159,6 +161,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PayClaim',
           period: 'Appeal',
           periodEndDate: addDays(new Date(), 2),
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -177,6 +180,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PayClaim',
           period: 'Execution',
           periodEndDate: null,
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -201,6 +205,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PaySettlement',
           period: 'Appeal',
           periodEndDate: addMinutes(new Date(), 1),
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -222,6 +227,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PaySettlement',
           period: 'Appeal',
           periodEndDate: addMinutes(new Date(), -1),
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -238,6 +244,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PaySettlement',
           period: 'Execution',
           periodEndDate: null,
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -258,6 +265,7 @@ describe('<ClaimActions />', () => {
           ruling: 'DoNotPay',
           period: 'Appeal',
           periodEndDate: addMinutes(new Date(), 1),
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -278,6 +286,7 @@ describe('<ClaimActions />', () => {
           ruling: 'DoNotPay',
           period: 'Appeal',
           periodEndDate: addMinutes(new Date(), -1),
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -294,6 +303,7 @@ describe('<ClaimActions />', () => {
           ruling: 'DoNotPay',
           period: 'Execution',
           periodEndDate: null,
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -311,6 +321,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PaySettlement',
           period: 'Evidence',
           periodEndDate: addDays(new Date(), 2),
+          timesPerPeriod,
           appealedBy: '0x153EF0B488148k0aB0FED112334',
         };
 
@@ -329,6 +340,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PayClaim',
           period: 'Vote',
           periodEndDate: addDays(new Date(), 2),
+          timesPerPeriod,
           appealedBy: '0xD6b040736e948621c5b6E0a4944',
         };
 

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -135,12 +135,13 @@ describe('<ClaimActions />', () => {
     });
 
     it('shows claimant has escalated to Kleros', () => {
+      claim.deadline = addDays(new Date(), 10);
       claim.dispute = {
         id: '1',
         status: 'Waiting',
         ruling: 'DoNotPay',
         period: 'Evidence',
-        periodEndDate: addDays(new Date(), 2),
+        periodChangedAt: new Date(),
         timesPerPeriod,
         appealedBy: null,
       };
@@ -160,7 +161,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'PayClaim',
           period: 'Appeal',
-          periodEndDate: addDays(new Date(), 2),
+          periodChangedAt: addDays(new Date(), -2),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -179,7 +180,7 @@ describe('<ClaimActions />', () => {
           status: 'Solved',
           ruling: 'PayClaim',
           period: 'Execution',
-          periodEndDate: null,
+          periodChangedAt: new Date(),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -204,7 +205,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'PaySettlement',
           period: 'Appeal',
-          periodEndDate: addMinutes(new Date(), 1),
+          periodChangedAt: addDays(new Date(), -4),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -226,7 +227,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'PaySettlement',
           period: 'Appeal',
-          periodEndDate: addMinutes(new Date(), -1),
+          periodChangedAt: addDays(new Date(), -4),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -243,7 +244,7 @@ describe('<ClaimActions />', () => {
           status: 'Solved',
           ruling: 'PaySettlement',
           period: 'Execution',
-          periodEndDate: null,
+          periodChangedAt: new Date(),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -264,7 +265,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'DoNotPay',
           period: 'Appeal',
-          periodEndDate: addMinutes(new Date(), 1),
+          periodChangedAt: addDays(new Date(), -4),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -285,7 +286,7 @@ describe('<ClaimActions />', () => {
           status: 'Appealable',
           ruling: 'DoNotPay',
           period: 'Appeal',
-          periodEndDate: addMinutes(new Date(), -1),
+          periodChangedAt: addDays(new Date(), -4),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -302,7 +303,7 @@ describe('<ClaimActions />', () => {
           status: 'Solved',
           ruling: 'DoNotPay',
           period: 'Execution',
-          periodEndDate: null,
+          periodChangedAt: new Date(),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -315,13 +316,13 @@ describe('<ClaimActions />', () => {
 
     describe('when the ruling has been appealed', () => {
       it('shows that it has been appealed to Kleros', () => {
-        claim.deadline = addDays(new Date(), 8);
+        claim.deadline = addDays(new Date(), 10);
         claim.dispute = {
           id: '1',
           status: 'Waiting',
           ruling: 'PaySettlement',
           period: 'Evidence',
-          periodEndDate: addDays(new Date(), 2),
+          periodChangedAt: new Date(),
           timesPerPeriod,
           appealedBy: '0x153EF0B488148k0aB0FED112334',
         };
@@ -341,7 +342,7 @@ describe('<ClaimActions />', () => {
           status: 'Waiting',
           ruling: 'PayClaim',
           period: 'Vote',
-          periodEndDate: addDays(new Date(), 2),
+          periodChangedAt: addDays(new Date(), -4),
           timesPerPeriod,
           appealedBy: '0xD6b040736e948621c5b6E0a4944',
         };

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -5,7 +5,7 @@ import { addDays, addMinutes } from 'date-fns';
 import { parseApi3, parseUsd } from '../../utils';
 
 let claim: Claim;
-const timesPerPeriod = [280800, 583200, 583200, 388800];
+const periodTimes = { evidence: 280800, vote: 583200, appeal: 388800 };
 
 describe('<ClaimActions />', () => {
   beforeEach(() => {
@@ -142,7 +142,7 @@ describe('<ClaimActions />', () => {
         ruling: 'DoNotPay',
         period: 'Evidence',
         periodChangedAt: new Date(),
-        timesPerPeriod,
+        periodTimes,
         appealedBy: null,
       };
 
@@ -162,7 +162,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PayClaim',
           period: 'Appeal',
           periodChangedAt: addDays(new Date(), -2),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -181,7 +181,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PayClaim',
           period: 'Execution',
           periodChangedAt: new Date(),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -206,7 +206,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PaySettlement',
           period: 'Appeal',
           periodChangedAt: addDays(new Date(), -4),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -228,7 +228,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PaySettlement',
           period: 'Appeal',
           periodChangedAt: addDays(new Date(), -4),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -245,7 +245,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PaySettlement',
           period: 'Execution',
           periodChangedAt: new Date(),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -266,7 +266,7 @@ describe('<ClaimActions />', () => {
           ruling: 'DoNotPay',
           period: 'Appeal',
           periodChangedAt: addDays(new Date(), -4),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -287,7 +287,7 @@ describe('<ClaimActions />', () => {
           ruling: 'DoNotPay',
           period: 'Appeal',
           periodChangedAt: addDays(new Date(), -4),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -304,7 +304,7 @@ describe('<ClaimActions />', () => {
           ruling: 'DoNotPay',
           period: 'Execution',
           periodChangedAt: new Date(),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -323,7 +323,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PaySettlement',
           period: 'Evidence',
           periodChangedAt: new Date(),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: '0x153EF0B488148k0aB0FED112334',
         };
 
@@ -343,7 +343,7 @@ describe('<ClaimActions />', () => {
           ruling: 'PayClaim',
           period: 'Vote',
           periodChangedAt: addDays(new Date(), -4),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: '0xD6b040736e948621c5b6E0a4944',
         };
 

--- a/src/pages/claim-details/claim-actions.test.tsx
+++ b/src/pages/claim-details/claim-actions.test.tsx
@@ -315,6 +315,7 @@ describe('<ClaimActions />', () => {
 
     describe('when the ruling has been appealed', () => {
       it('shows that it has been appealed to Kleros', () => {
+        claim.deadline = addDays(new Date(), 8);
         claim.dispute = {
           id: '1',
           status: 'Waiting',
@@ -334,6 +335,7 @@ describe('<ClaimActions />', () => {
       });
 
       it('shows that API3 has appealed when it is not the claimant', () => {
+        claim.deadline = addDays(new Date(), 2);
         claim.dispute = {
           id: '1',
           status: 'Waiting',

--- a/src/pages/my-claims/claim-list.module.scss
+++ b/src/pages/my-claims/claim-list.module.scss
@@ -1,6 +1,4 @@
-@import '../../styles/variables.module.scss';
-
-$min-desktop-width: 900px;
+@import './variables.scss';
 
 .claimList {
   padding: 0;

--- a/src/pages/my-claims/claim-list.module.scss
+++ b/src/pages/my-claims/claim-list.module.scss
@@ -114,28 +114,10 @@ $min-desktop-width: 900px;
   }
 }
 
-[data-show-deadline='true'] {
-  @media (min-width: $min-desktop-width) and (max-width: 1144px) {
-    .claimId {
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-    }
-
-    .createdAt {
-      display: none;
-    }
-  }
-}
-
-.createdAt {
-  display: inline;
-
-  @media (min-width: $min-desktop-width) {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-  }
+.claimId {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .claimActionInfo {

--- a/src/pages/my-claims/claim-list.test.tsx
+++ b/src/pages/my-claims/claim-list.test.tsx
@@ -11,6 +11,7 @@ function render(element: ReactElement) {
 }
 
 let claim: Claim;
+const timesPerPeriod = [280800, 583200, 583200, 388800];
 
 describe('<ClaimList />', () => {
   beforeEach(() => {
@@ -123,6 +124,7 @@ describe('<ClaimList />', () => {
         ruling: 'DoNotPay',
         period: 'Evidence',
         periodEndDate: addDays(new Date(), 2),
+        timesPerPeriod,
         appealedBy: null,
       };
 
@@ -142,6 +144,7 @@ describe('<ClaimList />', () => {
           ruling: 'PayClaim',
           period: 'Appeal',
           periodEndDate: addDays(new Date(), 2),
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -159,6 +162,7 @@ describe('<ClaimList />', () => {
           ruling: 'PayClaim',
           period: 'Execution',
           periodEndDate: null,
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -185,6 +189,7 @@ describe('<ClaimList />', () => {
           ruling: 'PaySettlement',
           period: 'Appeal',
           periodEndDate: addMinutes(new Date(), 1),
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -204,6 +209,7 @@ describe('<ClaimList />', () => {
           ruling: 'PaySettlement',
           period: 'Execution',
           periodEndDate: null,
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -226,6 +232,7 @@ describe('<ClaimList />', () => {
           ruling: 'DoNotPay',
           period: 'Appeal',
           periodEndDate: addMinutes(new Date(), 1),
+          timesPerPeriod,
           appealedBy: null,
         };
 
@@ -245,6 +252,7 @@ describe('<ClaimList />', () => {
           ruling: 'DoNotPay',
           period: 'Execution',
           periodEndDate: null,
+          timesPerPeriod,
           appealedBy: null,
         };
 

--- a/src/pages/my-claims/claim-list.test.tsx
+++ b/src/pages/my-claims/claim-list.test.tsx
@@ -118,6 +118,7 @@ describe('<ClaimList />', () => {
     });
 
     it('shows that Kleros is evaluating', () => {
+      claim.deadline = addDays(new Date(), 8);
       claim.dispute = {
         id: '1',
         status: 'Waiting',

--- a/src/pages/my-claims/claim-list.test.tsx
+++ b/src/pages/my-claims/claim-list.test.tsx
@@ -118,13 +118,13 @@ describe('<ClaimList />', () => {
     });
 
     it('shows that Kleros is evaluating', () => {
-      claim.deadline = addDays(new Date(), 8);
+      claim.deadline = addDays(new Date(), 10);
       claim.dispute = {
         id: '1',
         status: 'Waiting',
         ruling: 'DoNotPay',
         period: 'Evidence',
-        periodEndDate: addDays(new Date(), 2),
+        periodChangedAt: new Date(),
         timesPerPeriod,
         appealedBy: null,
       };
@@ -144,7 +144,7 @@ describe('<ClaimList />', () => {
           status: 'Appealable',
           ruling: 'PayClaim',
           period: 'Appeal',
-          periodEndDate: addDays(new Date(), 2),
+          periodChangedAt: addDays(new Date(), -2),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -162,7 +162,7 @@ describe('<ClaimList />', () => {
           status: 'Solved',
           ruling: 'PayClaim',
           period: 'Execution',
-          periodEndDate: null,
+          periodChangedAt: new Date(),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -189,7 +189,7 @@ describe('<ClaimList />', () => {
           status: 'Appealable',
           ruling: 'PaySettlement',
           period: 'Appeal',
-          periodEndDate: addMinutes(new Date(), 1),
+          periodChangedAt: addDays(new Date(), -4),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -209,7 +209,7 @@ describe('<ClaimList />', () => {
           status: 'Solved',
           ruling: 'PaySettlement',
           period: 'Execution',
-          periodEndDate: null,
+          periodChangedAt: new Date(),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -232,7 +232,7 @@ describe('<ClaimList />', () => {
           status: 'Appealable',
           ruling: 'DoNotPay',
           period: 'Appeal',
-          periodEndDate: addMinutes(new Date(), 1),
+          periodChangedAt: addDays(new Date(), -4),
           timesPerPeriod,
           appealedBy: null,
         };
@@ -252,7 +252,7 @@ describe('<ClaimList />', () => {
           status: 'Solved',
           ruling: 'DoNotPay',
           period: 'Execution',
-          periodEndDate: null,
+          periodChangedAt: new Date(),
           timesPerPeriod,
           appealedBy: null,
         };

--- a/src/pages/my-claims/claim-list.test.tsx
+++ b/src/pages/my-claims/claim-list.test.tsx
@@ -11,7 +11,7 @@ function render(element: ReactElement) {
 }
 
 let claim: Claim;
-const timesPerPeriod = [280800, 583200, 583200, 388800];
+const periodTimes = { evidence: 280800, vote: 583200, appeal: 388800 };
 
 describe('<ClaimList />', () => {
   beforeEach(() => {
@@ -125,7 +125,7 @@ describe('<ClaimList />', () => {
         ruling: 'DoNotPay',
         period: 'Evidence',
         periodChangedAt: new Date(),
-        timesPerPeriod,
+        periodTimes,
         appealedBy: null,
       };
 
@@ -145,7 +145,7 @@ describe('<ClaimList />', () => {
           ruling: 'PayClaim',
           period: 'Appeal',
           periodChangedAt: addDays(new Date(), -2),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -163,7 +163,7 @@ describe('<ClaimList />', () => {
           ruling: 'PayClaim',
           period: 'Execution',
           periodChangedAt: new Date(),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -190,7 +190,7 @@ describe('<ClaimList />', () => {
           ruling: 'PaySettlement',
           period: 'Appeal',
           periodChangedAt: addDays(new Date(), -4),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -210,7 +210,7 @@ describe('<ClaimList />', () => {
           ruling: 'PaySettlement',
           period: 'Execution',
           periodChangedAt: new Date(),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -233,7 +233,7 @@ describe('<ClaimList />', () => {
           ruling: 'DoNotPay',
           period: 'Appeal',
           periodChangedAt: addDays(new Date(), -4),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 
@@ -253,7 +253,7 @@ describe('<ClaimList />', () => {
           ruling: 'DoNotPay',
           period: 'Execution',
           periodChangedAt: new Date(),
-          timesPerPeriod,
+          periodTimes,
           appealedBy: null,
         };
 

--- a/src/pages/my-claims/claim-list.tsx
+++ b/src/pages/my-claims/claim-list.tsx
@@ -3,6 +3,7 @@ import Timer from '../../components/timer';
 import Api3Icon from '../../components/icons/api3-icon';
 import KlerosIcon from '../../components/icons/kleros-icon';
 import WarningIcon from '../../components/icons/warning-icon';
+import { Api3EvaluatingIndicator, KlerosEvaluatingIndicator } from './evaluating-indicators';
 import { isAfter } from 'date-fns';
 import { images, useForceUpdate } from '../../utils';
 import { abbrStr, Claim } from '../../chain-data';
@@ -67,7 +68,14 @@ export default function ClaimList(props: Props) {
 
               <div className={styles.claimActionInfo} data-testid="claim-action-info">
                 {pills && <div className={styles.pillContainer}>{pills}</div>}
-                {showDeadline && <Timer deadline={currentDeadline} onDeadlineExceeded={forceUpdate} />}
+
+                {isApi3Evaluating(claim, isPastDeadline) ? (
+                  <Api3EvaluatingIndicator claim={claim} onDeadlineExceeded={forceUpdate} />
+                ) : isKlerosEvaluating(claim) ? (
+                  <KlerosEvaluatingIndicator claim={claim} onDeadlineExceeded={forceUpdate} />
+                ) : showDeadline ? (
+                  <Timer deadline={currentDeadline} onDeadlineExceeded={forceUpdate} />
+                ) : null}
               </div>
               <Link className={styles.arrowIconLink} tabIndex={-1} to={`/claims/${claim.claimId}`}>
                 <img src={images.arrowRight} alt="right arrow" />
@@ -278,4 +286,12 @@ function getClaimActions(claim: Claim, isPastDeadline: boolean) {
     default:
       return null;
   }
+}
+
+function isApi3Evaluating(claim: Claim, isPastDeadline: boolean) {
+  return claim.status === 'ClaimCreated' && !isPastDeadline;
+}
+
+function isKlerosEvaluating(claim: Claim) {
+  return claim.status === 'DisputeCreated' && claim?.dispute?.status === 'Waiting';
 }

--- a/src/pages/my-claims/claim-list.tsx
+++ b/src/pages/my-claims/claim-list.tsx
@@ -3,7 +3,7 @@ import Timer from '../../components/timer';
 import Api3Icon from '../../components/icons/api3-icon';
 import KlerosIcon from '../../components/icons/kleros-icon';
 import WarningIcon from '../../components/icons/warning-icon';
-import { format, isAfter } from 'date-fns';
+import { isAfter } from 'date-fns';
 import { images, useForceUpdate } from '../../utils';
 import { abbrStr, Claim } from '../../chain-data';
 import { getCurrentDeadline, isActive, useClaimPayoutDataPreload } from '../../logic/claims';
@@ -39,7 +39,6 @@ export default function ClaimList(props: Props) {
             data-active={active}
             data-status={claim.status}
             data-dispute-status={claim.dispute?.status}
-            data-show-deadline={showDeadline}
             data-testid="claim-list-item"
           >
             <div className={styles.mobileStatusRow}>
@@ -62,12 +61,6 @@ export default function ClaimList(props: Props) {
                   <span className={styles.claimId}>
                     <span className={globalStyles.tertiaryColor}>Claim ID: </span>
                     {abbrStr(claim.claimId, { startLength: 5 })}
-                  </span>
-
-                  <span className={styles.createdAt}>
-                    <span className={globalStyles.tertiaryColor}>Created: </span>
-                    {format(claim.timestamp, 'dd MMM yyyy')}
-                    <span className={globalStyles.tertiaryColor}> {format(claim.timestamp, 'HH:mm')}</span>
                   </span>
                 </div>
               </div>

--- a/src/pages/my-claims/evaluating-indicators.module.scss
+++ b/src/pages/my-claims/evaluating-indicators.module.scss
@@ -1,0 +1,34 @@
+@import './variables.scss';
+
+.evaluatingIndicator {
+  display: none;
+  font-size: $text-xsmall;
+  line-height: $lh-xsmall;
+  color: $tertiary-color;
+
+  @media (min-width: $min-desktop-width) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5ch;
+  }
+
+  svg {
+    height: 14px;
+    width: 18px;
+    min-width: 18px;
+  }
+
+  button {
+    background: transparent;
+    border: none;
+    display: inline-flex;
+    align-items: center;
+    padding: 0;
+    margin-left: 0.5ch;
+    svg {
+      height: 20px;
+      width: 20px;
+      color: $secondary-color;
+    }
+  }
+}

--- a/src/pages/my-claims/evaluating-indicators.tsx
+++ b/src/pages/my-claims/evaluating-indicators.tsx
@@ -2,7 +2,7 @@ import Api3Icon from '../../components/icons/api3-icon';
 import KlerosIcon from '../../components/icons/kleros-icon';
 import InfoIcon from '../../components/icons/info-icon';
 import { Tooltip } from '../../components/tooltip';
-import { useCountdown } from '../../components/timer';
+import { useCountdown } from '../../components/timer/hooks';
 import { Claim } from '../../chain-data';
 import { formatDistanceToNow } from 'date-fns';
 import styles from './evaluating-indicators.module.scss';

--- a/src/pages/my-claims/evaluating-indicators.tsx
+++ b/src/pages/my-claims/evaluating-indicators.tsx
@@ -1,0 +1,63 @@
+import Api3Icon from '../../components/icons/api3-icon';
+import KlerosIcon from '../../components/icons/kleros-icon';
+import InfoIcon from '../../components/icons/info-icon';
+import { Tooltip } from '../../components/tooltip';
+import { useCountdown } from '../../components/timer';
+import { Claim } from '../../chain-data';
+import { formatDistanceToNow } from 'date-fns';
+import styles from './evaluating-indicators.module.scss';
+
+interface Props {
+  claim: Claim;
+  onDeadlineExceeded: () => void;
+}
+
+export function Api3EvaluatingIndicator(props: Props) {
+  const { claim } = props;
+  useCountdown(claim.deadline!, props.onDeadlineExceeded);
+
+  const tooltipId = `tooltip-${claim.claimId}`;
+  return (
+    <span className={styles.evaluatingIndicator}>
+      <Api3Icon aria-hidden />
+      API3 Mediators evaluating
+      <Tooltip
+        id={tooltipId}
+        overlay={`The API3 Mediators will respond to your claim within ${formatDistanceToNow(claim.deadline!)}.`}
+      >
+        <button aria-describedby={tooltipId}>
+          <InfoIcon aria-hidden />
+          <span className="sr-only">View info</span>
+        </button>
+      </Tooltip>
+    </span>
+  );
+}
+
+export function KlerosEvaluatingIndicator(props: Props) {
+  const { claim } = props;
+  const countdown = useCountdown(claim.deadline!, props.onDeadlineExceeded);
+
+  const tooltipId = `tooltip-${claim.claimId}`;
+  return (
+    <span className={styles.evaluatingIndicator}>
+      <KlerosIcon aria-hidden />
+      Kleros evaluating
+      <Tooltip
+        id={tooltipId}
+        overlay={
+          countdown.dateDiff > 0
+            ? `Kleros should respond to your claim within ${formatDistanceToNow(claim.deadline!)}.`
+            : // We might end up here in the brief moment after the voting period has passed and the KlerosLiquid "passPeriod()" smart contract
+              // function has not yet been called to move the dispute into its appeal period.
+              'Kleros should respond to your claim soon.'
+        }
+      >
+        <button aria-describedby={tooltipId}>
+          <InfoIcon aria-hidden />
+          <span className="sr-only">View info</span>
+        </button>
+      </Tooltip>
+    </span>
+  );
+}

--- a/src/pages/my-claims/variables.scss
+++ b/src/pages/my-claims/variables.scss
@@ -1,0 +1,3 @@
+@import '../../styles/variables.module.scss';
+
+$min-desktop-width: 900px;


### PR DESCRIPTION
### What does this change?
- it calculates a deadline for Kleros evaluation
- it uses a different mechanism for showing the remaining evaluation time (on the claim list) to better communicate that the deadline is on API3/Kleros' side
- it removes the "created at" date from the claim list items

### How did you action this task?
Kleros gives their ruling after the `Vote` period, so when we are in the `Evidence` period, we get the vote period end date by adding the vote period to the evidence period (the commit period is skipped because the sub court does not have hidden votes).

```ts
// Evidence period
deadline = addSeconds(dispute.periodChangedAt, evidencePeriodLength + votePeriodLength);
```
The period lengths are provided by the sub court (`subCourt.timesPerPeriod[]`)

### Screenshots
<img width="401" alt="Screenshot 2022-11-28 at 15 05 16" src="https://user-images.githubusercontent.com/747979/204316277-caf7cf5d-9413-4b23-a162-4e68c29e64dc.png">
<img width="539" alt="Screenshot 2022-11-28 at 13 30 55" src="https://user-images.githubusercontent.com/747979/204316322-c6f33c72-7932-4351-a6f4-2a4f7436feb7.png">
