### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ The implementation of the DAO dashboard.
 
 [![ContinuousBuild](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml)
 
+We use the `main` branch to develop new features. For production code, see the
+[the production branch](https://github.com/api3dao/api3-dao-dashboard/tree/production).
+
+## Development instructions
+
+You can find development instructions in a separate [dev-README](./dev-README.md).
+
 ## Running the dashboard on Mainnet in a Docker container
 
 The decentralized approach to being a DAO member is to run API3 dashboard on your local machine. For that you will just
@@ -12,6 +19,8 @@ need `docker` and, optionally, `git`.
 There are two approaches to running the dashboard locally. The first involves using the prebuilt Docker image, while the
 second involves building the image from source. In either case, the end result is a API3 dashboard running on port 7770
 of your localhost where it is safe to connect your wallet.
+
+Currently, it's only possible to build the Docker image on a UNIX-like OS. If you use Windows, you can use WSL2.
 
 ### Running the prebuilt image
 
@@ -34,100 +43,7 @@ docker build --tag api3-dao-dashboard .
 docker run --rm --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
 ```
 
-## Development instructions
-
-We use the `main` branch to develop new features. For production code, see the
-[the production branch](https://github.com/api3dao/api3-dao-dashboard/tree/production).
-
-Currently, it's only possible to build the Docker image on a UNIX-like OS. If you use Windows, you can use WSL2.
-
-### Running on mainnet or testnets
-
-1. `yarn` - to install dependencies and generate TypeScript types
-2. `yarn start` - to start the application on localhost on port 3000
-
-### Running with hardhat
-
-1. `yarn` - to install dependencies and generate TypeScript types
-2. `yarn eth:node` - to start hardhat network
-3. `yarn eth:prepare-dao-contracts-for-hardhat` - to download the DAO contract sources locally. You need to run this
-   only when running for the first time.
-4. (Optional) Modify the pool contract `EPOCH_LENGTH` variable from `1 weeks` to `1 minutes` to speed up testing. You
-   can find this constant inside `dao-contracts/packages/pool/contracts/StateUtils.sol`
-5. `yarn eth:deploy-dao-contracts-on-hardhat` - to deploy the contracts locally
-6. Copy the `.env.example` to `.env`. Make sure that `REACT_APP_NODE_ENV` is set to `development`
-7. `yarn start` - to start the application on localhost on port 3000
-8. `yarn send-to-account <address> --ether 5 --tokens 100` to send some ETH and tokens to your account
-
-<!-- markdown-link-check-disable -->
-<!-- The "how to reset account link does work, but the github actions check says it returns 403" -->
-
-> MetaMask doesn't handle localhost development ideally. Particularly, that the chain is reset after on every
-> `yarn eth:node` command. In case you have problems making a transaction, try to
-> [reset the account](https://metamask.zendesk.com/hc/en-us/articles/360015488891-How-to-reset-your-wallet).
-
-<!-- markdown-link-check-enable -->
-
-### Supported networks
-
-Currently, only `hardhat`, `rinkeby` and `mainnet` networks are supported. If you want to test the application on a
-different network, adapt the configuration to your needs.
-
-## Hosting
-
-We use [Fleek](https://fleek.co/) to host the application on IPFS. The hosting workflow works like this:
-
-- Every PR against `main` branch will be deployed by github action (as preview deployment) and you can find the IPFS
-  hash in the "fleek deploy check" details in the PR status checks panel.
-- The current version of app in `main` branch will be deployed as staging on the following URL:
-  https://api3-dao-dashboard-staging.on.fleek.co/. The app will be redeployed after every merged request automatically
-- Every push to `production` branch will trigger a production deploy. The app can be found on this URL:
-  https://api3-dao-dashboard.on.fleek.co/
-
-Apart from that, we are using
-[environment variables](https://create-react-app.dev/docs/adding-custom-environment-variables/), specifically
-`REACT_APP_NODE_ENV` to specify the environment. Possible values `development`, `staging` and `production`.
-
-### Hosting new version of production app
-
-All you need to do is push the code to `production` branch. Most of the times you just want to copy what's on `main`
-branch:
-
-1. `git checkout production`
-2. `git merge main`
-3. `git push`
-
-### Updating the name servers
-
-The primary way to access the DAO dashboard is through the `api3.eth` ENS name, which points directly to the IPFS hash.
-Then, the user can either connect to mainnet on their Metamask and visit `api3.eth/` (the recommended way), or they can
-visit `https://api3.eth.link/`.
-
-<!-- markdown-link-check-disable -->
-<!-- The link below exists and works, but the github actions check says it does not" -->
-
-Unfortunately, the `https://api3.eth.link/` is reported to be down frequently, see
-[this](https://blog.cloudflare.com/cloudflare-distributed-web-resolver/) for more information.
-
-<!-- markdown-link-check-enable -->
-
-After pushing to the production branch, verify the Fleek build (see below). Then,
-[point `api3.eth` to the new CID](https://docs.ipfs.io/how-to/websites-on-ipfs/link-a-domain/#ethereum-naming-service-ens).
-
-<!-- markdown-link-check-disable -->
-<!-- The link below exists and works, but the github actions check says it does not" -->
-
-Then, with the Cloudflare account that manages `api3.org`,
-[update the page rule](https://support.cloudflare.com/hc/en-us/articles/200172286-Configuring-URL-forwarding-or-redirects-with-Cloudflare-Page-Rules)
-to direct `https://api3.eth.link/#/` to the URL pointing to the new deployment through the `dweb.link` gateway (you can
-get this URL from the [ENS dashboard](https://app.ens.domains/name/api3.eth)).
-
-<!-- markdown-link-check-enable -->
-
-`api3.eth/` will start forwarding to the new deployment instantly, while `https://api3.eth.link/` will have to wait for
-the DNS information to propagate (may take up to 2 hours).
-
-### Verifying the Fleek build
+## Verifying the Fleek build
 
 We're using Fleek to build and deploy the dashboard. To avoid trusting Fleek to build and deploy the app correctly, one
 can also build it locally and compare its hash with the IPFS deployment.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# api3-dao-dashboard
+# api3-dao-dashboard [![ContinuousBuild](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml)
 
 The implementation of the DAO dashboard.
-
-[![ContinuousBuild](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml)
 
 We use the `main` branch to develop new features. For production code, see the
 [production branch](https://github.com/api3dao/api3-dao-dashboard/tree/production).
@@ -46,7 +44,7 @@ docker run --rm --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
 ## Verifying the Fleek build
 
 We're using Fleek to build and deploy the dashboard. To avoid trusting Fleek with build and deployments, one can also
-build the app locally and compare its hash with the has of IPFS deployment.
+build the app locally and compare its hash with the hash of IPFS deployment.
 
 To do so, first create a `docker-compose.yml` as explained
 [here](https://docs.fleek.co/hosting/site-deployment/#testing-deployments-locally) in this repo.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The implementation of the DAO dashboard.
 [![ContinuousBuild](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/api3dao/api3-dao-dashboard/actions/workflows/main.yml)
 
 We use the `main` branch to develop new features. For production code, see the
-[the production branch](https://github.com/api3dao/api3-dao-dashboard/tree/production).
+[production branch](https://github.com/api3dao/api3-dao-dashboard/tree/production).
 
 ## Development instructions
 
@@ -24,8 +24,8 @@ Currently, it's only possible to build the Docker image on a UNIX-like OS. If yo
 
 ### Running the prebuilt image
 
-The simplest way to run the dashboard is using the prebuilt Docker image. This image is built and pushed to Docker Hub
-via a GitHub Actions workflow triggered by commits to the `production` branch.
+The simplest way to run the dashboard locally is using the prebuilt Docker image. This image is built and pushed to
+Docker Hub automatically when new commits are added to the `production` branch.
 
 ```sh
 docker run --rm --publish 7770:80 --name api3-dao-dashboard api3/dao-dashboard:latest
@@ -33,7 +33,7 @@ docker run --rm --publish 7770:80 --name api3-dao-dashboard api3/dao-dashboard:l
 
 ### Building from source
 
-Alternatively, you can build the Docker image from source. Note that the production source code is on the `production`
+Alternatively, you can build the Docker image from source. Note that the production code is located on the `production`
 branch.
 
 ```sh
@@ -45,11 +45,11 @@ docker run --rm --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
 
 ## Verifying the Fleek build
 
-We're using Fleek to build and deploy the dashboard. To avoid trusting Fleek to build and deploy the app correctly, one
-can also build it locally and compare its hash with the IPFS deployment.
+We're using Fleek to build and deploy the dashboard. To avoid trusting Fleek with build and deployments, one can also
+build the app locally and compare its hash with the has of IPFS deployment.
 
 To do so, first create a `docker-compose.yml` as explained
-[here](https://docs.fleek.co/hosting/site-deployment/#testing-deployments-locally) in this repo
+[here](https://docs.fleek.co/hosting/site-deployment/#testing-deployments-locally) in this repo.
 
 ```yml
 version: '3.7'
@@ -75,12 +75,12 @@ and run `docker-compose run --rm app`, which will create a `./build` directory.
 
 Then, (after installing `ipfs`) run `sudo ipfs add --only-hash --recursive ./build` to get the hash of the build (`sudo`
 because `build` will likely be owned by root). This should be the same as the IPFS hash as the one on the Fleek
-dashboard and what our ENS is pointing towards.
+dashboard and what our ENS record is pointing towards.
 
 ## Error Monitoring
 
 Please note that the API3 core team tracks application errors on test and production environments using
-[Sentry](https://sentry.io). This is solely used to fix errors and improve the user experience.
+[Sentry](https://sentry.io). This is solely used to fix errors and improve the experience of our users.
 
 **NOTE: No identifying user information is collected**
 

--- a/dev-README.md
+++ b/dev-README.md
@@ -1,12 +1,7 @@
 # Development instructions
 
-The DAO dashboard README is reserved for tech savvy users who want to learn more about production environment. All
-development oriented can be found here.
-
-## Running on mainnet or testnets
-
-1. `yarn` - to install dependencies and generate TypeScript types
-2. `yarn start` - to start the application on localhost on port 3000
+The DAO dashboard README is reserved for tech savvy users who want to learn more about how is the DAO dashboard
+implemented. All developer oriented instructions can be found here.
 
 ## Running with hardhat
 
@@ -39,52 +34,26 @@ different network, adapt the configuration to your needs.
 
 We use [Fleek](https://fleek.co/) to host the application on IPFS. The hosting workflow works like this:
 
-- Every PR against `main` branch will be deployed by github action (as preview deployment) and you can find the IPFS
+- Every PR against `main` branch will be deployed by Github Actions (as preview deployment) and you can find the IPFS
   hash in the "fleek deploy check" details in the PR status checks panel.
 - The current version of app in `main` branch will be deployed as staging on the following URL:
-  https://api3-dao-dashboard-staging.on.fleek.co/. The app will be redeployed after every merged request automatically
-- Every push to `production` branch will trigger a production deploy. The app can be found on this URL:
-  https://api3-dao-dashboard.on.fleek.co/
+  https://api3-dao-dashboard-staging.on.fleek.co/. The app will be redeployed after every merged request automatically.
+- Every push to `production` branch will trigger a production deploy. The productions can be found on this URL:
+  https://api3-dao-dashboard.on.fleek.co/.
 
-Apart from that, we are using
-[environment variables](https://create-react-app.dev/docs/adding-custom-environment-variables/), specifically
-`REACT_APP_NODE_ENV` to specify the environment. Possible values `development`, `staging` and `production`.
+On Fleek, we are using [environment variables](https://create-react-app.dev/docs/adding-custom-environment-variables/),
+specifically `REACT_APP_NODE_ENV` to specify the environment. Possible values `development`, `staging` and `production`.
 
-### Hosting new version of production app
+### Updating the production deployment
 
-All you need to do is push the code to `production` branch. Most of the times you just want to copy what's on `main`
-branch:
-
-1. `git checkout production`
-2. `git merge main`
-3. `git push`
+All you need to do is merge a PR to `production` branch. Most of the times you just want to open a new PR from the
+`main` branch.
 
 ### Updating the name servers
 
 The primary way to access the DAO dashboard is through the `api3.eth` ENS name, which points directly to the IPFS hash.
-Then, the user can either connect to mainnet on their Metamask and visit `api3.eth/` (the recommended way), or they can
-visit `https://api3.eth.link/`.
+Then, the user can either connect to mainnet on their Metamask (or use a browser which supports resolving .eth domains)
+and visit `api3.eth/`.
 
-<!-- markdown-link-check-disable -->
-<!-- The link below exists and works, but the github actions check says it does not" -->
-
-Unfortunately, the `https://api3.eth.link/` is reported to be down frequently, see
-[this](https://blog.cloudflare.com/cloudflare-distributed-web-resolver/) for more information.
-
-<!-- markdown-link-check-enable -->
-
-After pushing to the production branch, verify the Fleek build (see below). Then,
+After pushing to the production branch, [verify the Fleek build](./README.md#verifying-the-fleek-build). Then,
 [point `api3.eth` to the new CID](https://docs.ipfs.io/how-to/websites-on-ipfs/link-a-domain/#ethereum-naming-service-ens).
-
-<!-- markdown-link-check-disable -->
-<!-- The link below exists and works, but the github actions check says it does not" -->
-
-Then, with the Cloudflare account that manages `api3.org`,
-[update the page rule](https://support.cloudflare.com/hc/en-us/articles/200172286-Configuring-URL-forwarding-or-redirects-with-Cloudflare-Page-Rules)
-to direct `https://api3.eth.link/#/` to the URL pointing to the new deployment through the `dweb.link` gateway (you can
-get this URL from the [ENS dashboard](https://app.ens.domains/name/api3.eth)).
-
-<!-- markdown-link-check-enable -->
-
-`api3.eth/` will start forwarding to the new deployment instantly, while `https://api3.eth.link/` will have to wait for
-the DNS information to propagate (may take up to 2 hours).

--- a/dev-README.md
+++ b/dev-README.md
@@ -1,0 +1,90 @@
+# Development instructions
+
+The DAO dashboard README is reserved for tech savvy users who want to learn more about production environment. All
+development oriented can be found here.
+
+## Running on mainnet or testnets
+
+1. `yarn` - to install dependencies and generate TypeScript types
+2. `yarn start` - to start the application on localhost on port 3000
+
+## Running with hardhat
+
+1. `yarn` - to install dependencies and generate TypeScript types
+2. `yarn eth:node` - to start hardhat network
+3. `yarn eth:prepare-dao-contracts-for-hardhat` - to download the DAO contract sources locally. You need to run this
+   only when running for the first time.
+4. (Optional) Modify the pool contract `EPOCH_LENGTH` variable from `1 weeks` to `1 minutes` to speed up testing. You
+   can find this constant inside `dao-contracts/packages/pool/contracts/StateUtils.sol`
+5. `yarn eth:deploy-dao-contracts-on-hardhat` - to deploy the contracts locally
+6. Copy the `.env.example` to `.env`. Make sure that `REACT_APP_NODE_ENV` is set to `development`
+7. `yarn start` - to start the application on localhost on port 3000
+8. `yarn send-to-account <address> --ether 5 --tokens 100` to send some ETH and tokens to your account
+
+<!-- markdown-link-check-disable -->
+<!-- The "how to reset account link does work, but the github actions check says it returns 403" -->
+
+> MetaMask doesn't handle localhost development ideally. Particularly, that the chain is reset after on every
+> `yarn eth:node` command. In case you have problems making a transaction, try to
+> [reset the account](https://metamask.zendesk.com/hc/en-us/articles/360015488891-How-to-reset-your-wallet).
+
+<!-- markdown-link-check-enable -->
+
+## Supported networks
+
+Currently, only `hardhat`, `rinkeby` and `mainnet` networks are supported. If you want to test the application on a
+different network, adapt the configuration to your needs.
+
+## Hosting
+
+We use [Fleek](https://fleek.co/) to host the application on IPFS. The hosting workflow works like this:
+
+- Every PR against `main` branch will be deployed by github action (as preview deployment) and you can find the IPFS
+  hash in the "fleek deploy check" details in the PR status checks panel.
+- The current version of app in `main` branch will be deployed as staging on the following URL:
+  https://api3-dao-dashboard-staging.on.fleek.co/. The app will be redeployed after every merged request automatically
+- Every push to `production` branch will trigger a production deploy. The app can be found on this URL:
+  https://api3-dao-dashboard.on.fleek.co/
+
+Apart from that, we are using
+[environment variables](https://create-react-app.dev/docs/adding-custom-environment-variables/), specifically
+`REACT_APP_NODE_ENV` to specify the environment. Possible values `development`, `staging` and `production`.
+
+### Hosting new version of production app
+
+All you need to do is push the code to `production` branch. Most of the times you just want to copy what's on `main`
+branch:
+
+1. `git checkout production`
+2. `git merge main`
+3. `git push`
+
+### Updating the name servers
+
+The primary way to access the DAO dashboard is through the `api3.eth` ENS name, which points directly to the IPFS hash.
+Then, the user can either connect to mainnet on their Metamask and visit `api3.eth/` (the recommended way), or they can
+visit `https://api3.eth.link/`.
+
+<!-- markdown-link-check-disable -->
+<!-- The link below exists and works, but the github actions check says it does not" -->
+
+Unfortunately, the `https://api3.eth.link/` is reported to be down frequently, see
+[this](https://blog.cloudflare.com/cloudflare-distributed-web-resolver/) for more information.
+
+<!-- markdown-link-check-enable -->
+
+After pushing to the production branch, verify the Fleek build (see below). Then,
+[point `api3.eth` to the new CID](https://docs.ipfs.io/how-to/websites-on-ipfs/link-a-domain/#ethereum-naming-service-ens).
+
+<!-- markdown-link-check-disable -->
+<!-- The link below exists and works, but the github actions check says it does not" -->
+
+Then, with the Cloudflare account that manages `api3.org`,
+[update the page rule](https://support.cloudflare.com/hc/en-us/articles/200172286-Configuring-URL-forwarding-or-redirects-with-Cloudflare-Page-Rules)
+to direct `https://api3.eth.link/#/` to the URL pointing to the new deployment through the `dweb.link` gateway (you can
+get this URL from the [ENS dashboard](https://app.ens.domains/name/api3.eth)).
+
+<!-- markdown-link-check-enable -->
+
+`api3.eth/` will start forwarding to the new deployment instantly, while `https://api3.eth.link/` will have to wait for
+the DNS information to propagate (may take up to 2 hours).

--- a/dev-README.md
+++ b/dev-README.md
@@ -1,7 +1,7 @@
 # Development instructions
 
 The DAO dashboard README is reserved for tech savvy users who want to learn more about how is the DAO dashboard
-implemented. All developer oriented instructions can be found here.
+implemented and its security. All developer oriented instructions can be found here.
 
 ## Running with hardhat
 
@@ -38,7 +38,7 @@ We use [Fleek](https://fleek.co/) to host the application on IPFS. The hosting w
   hash in the "fleek deploy check" details in the PR status checks panel.
 - The current version of app in `main` branch will be deployed as staging on the following URL:
   https://api3-dao-dashboard-staging.on.fleek.co/. The app will be redeployed after every merged request automatically.
-- Every push to `production` branch will trigger a production deploy. The productions can be found on this URL:
+- Every push to `production` branch will trigger a production deploy. The production can be found on this URL:
   https://api3-dao-dashboard.on.fleek.co/.
 
 On Fleek, we are using [environment variables](https://create-react-app.dev/docs/adding-custom-environment-variables/),


### PR DESCRIPTION
Based on the discussion in https://api3workspace.slack.com/archives/C02ALA11APM/p1678093121848019

The README recommends to update the `.eth.link` domain, which is no longer owned by Cloudflare and [should not be used anymore](https://twitter.com/luigyGT/status/1554092735229034496). MetaMask seems to [block](https://github.com/MetaMask/eth-phishing-detect/issues/11814) these URLs already. I've removed this part of docs.

While reading the README I got a feeling we are mixing content for two audiences, tech savvy users and developers. I've decided to move developer instructions to separate dev-README. I still think keeping the `main` (not production) branch as a default branch is good idea. Wdyt?

I've also updated the GH "about section" to use [api3.eth/](http://api3.eth/). Btw. for this I had to edit the input type to text, because it is not a valid URL according to type URL 😄 