### PR TITLE
Allow simple ETH transfer proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ cypress-shared.json
 cypress/videos
 cypress/screenshots
 cypress/fixtures
+cypress/downloads
 
 # A folder for temporary project related files
 /tmp

--- a/cypress/e2e/new-proposal.cy.ts
+++ b/cypress/e2e/new-proposal.cy.ts
@@ -13,20 +13,18 @@ it('new proposal form validation', () => {
   cy.findByText('Create').click();
   cy.findByText('Title must have at least one alphanumeric character').should('exist');
   cy.findByText('Description must have at least one alphanumeric character').should('exist');
-  cy.findByText('Make sure parameters is a valid JSON array').should('exist');
+  cy.findByText('Please specify a valid account address').should('exist');
   cy.percySnapshot('Governance: New proposal modal', { minHeight: 1500 });
 
-  // Correct the errors
+  // Correct the errors, but fill in invalid parameters
   cy.findByLabelText('Title').type('Getting University Blockchain Groups Involved in Governance');
   cy.findByLabelText('Description').type('https://forum.api3.org/t/getting-university-blockchain-groups-involved');
   cy.findByLabelText('Parameters').type('{}');
   cy.findByText('Create').click();
+
+  // Let user fix invalid parameters, but make them inconsistent with the target contract signature
   cy.findByText('Make sure parameters is a valid JSON array').should('exist');
   cy.findByLabelText('Parameters').clear().type('[]');
-  cy.findByText('Create').click();
-
-  // Expect contract signature error and let user fix it
-  cy.findByText('Please specify a valid contract signature').should('exist');
   cy.findByLabelText('Target Contract Signature').type('transfer(address, unit256)');
   cy.findByText('Create').click();
 

--- a/cypress/e2e/new-proposal.cy.ts
+++ b/cypress/e2e/new-proposal.cy.ts
@@ -13,7 +13,7 @@ it('new proposal form validation', () => {
   cy.findByText('Create').click();
   cy.findByText('Title must have at least one alphanumeric character').should('exist');
   cy.findByText('Description must have at least one alphanumeric character').should('exist');
-  cy.findByText('Please specify a valid account address').should('exist');
+  cy.findByText('Make sure parameters is a valid JSON array').should('exist');
   cy.percySnapshot('Governance: New proposal modal', { minHeight: 1500 });
 
   // Correct the errors, but fill in invalid parameters

--- a/cypress/e2e/new-proposal.cy.ts
+++ b/cypress/e2e/new-proposal.cy.ts
@@ -42,7 +42,7 @@ it('new proposal form validation', () => {
 
   // Fill target address and value
   cy.findByText('Please specify a valid account address').should('exist');
-  cy.findByLabelText('Target Contract Address').type(ACCOUNTS[1]);
+  cy.findByLabelText('Target Address').type(ACCOUNTS[1]);
   cy.findByLabelText('Value (Wei)').type('-123456');
   cy.findByText('Create').click();
 

--- a/src/chain-data/state.ts
+++ b/src/chain-data/state.ts
@@ -41,7 +41,7 @@ export type TreasuryType = 'primary' | 'secondary';
 
 export interface DecodedEvmScript {
   targetAddress: string;
-  parameters: unknown[] | null;
+  parameters: unknown[];
   value: BigNumber; // amount of ETH that is sent to the contract
 }
 export interface Proposal {

--- a/src/chain-data/state.ts
+++ b/src/chain-data/state.ts
@@ -30,7 +30,7 @@ export interface DashboardState extends ConvenienceDashboardData {
 export interface ProposalMetadata {
   version: string;
   title: string;
-  targetSignature: string;
+  targetSignature: string | null;
   description: string;
 }
 
@@ -41,7 +41,7 @@ export type TreasuryType = 'primary' | 'secondary';
 
 export interface DecodedEvmScript {
   targetAddress: string;
-  parameters: unknown[];
+  parameters: unknown[] | null;
   value: BigNumber; // amount of ETH that is sent to the contract
 }
 export interface Proposal {

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -119,6 +119,20 @@ describe('encoding incorrect params', () => {
       new EncodedEvmScriptError('targetValue', 'Value must be greater than 0 for ETH transfers')
     );
   });
+
+  it('empty array parameters ("[]") for simple ETH transfer', async () => {
+    const invalidData = updateImmutably(newFormData, (data) => {
+      data.parameters = '[]';
+      data.targetSignature = '';
+    });
+
+    const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
+
+    assertGoError(goRes);
+    expect(goRes.error).toEqual(
+      new EncodedEvmScriptError('parameters', 'Please specify an empty string for parameters for simple ETH transfer')
+    );
+  });
 });
 
 describe('encoding invalid target signature', () => {
@@ -157,7 +171,7 @@ describe('encoding invalid target signature', () => {
 
     assertGoError(goRes);
     expect(goRes.error).toEqual(
-      new EncodedEvmScriptError('parameters', 'Please specify the correct number of function arguments')
+      new EncodedEvmScriptError('parameters', 'Please specify an empty string for parameters for simple ETH transfer')
     );
   });
 });

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -35,14 +35,14 @@ const mockedProvider: providers.JsonRpcProvider = {
   },
 } as any;
 
-test('correct encoding', async () => {
+test('correct contract call proposal', async () => {
   const goRes = await goEncodeEvmScript(mockedProvider, newFormData, api3Agent);
 
   assertGoSuccess(goRes);
   expect(goRes.data).toBeDefined();
 });
 
-it('allows simple ETH transfers using zero length parameters and empty target signature', async () => {
+test('simple ETH transfers using zero length parameters and empty target signature', async () => {
   const validData = updateImmutably(newFormData, (data) => {
     data.parameters = '[]';
     data.targetSignature = '';
@@ -54,8 +54,8 @@ it('allows simple ETH transfers using zero length parameters and empty target si
   expect(goRes.data).toBeDefined();
 });
 
-describe('encoding incorrect params', () => {
-  it('incorrect parameter values', async () => {
+describe('encoding incorrect parameters', () => {
+  test('incorrect parameter values', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
       data.parameters = JSON.stringify([123, 'arg1']); // they are in the wrong order
     });
@@ -68,7 +68,7 @@ describe('encoding incorrect params', () => {
     );
   });
 
-  it('wrong shape', async () => {
+  test('wrong shape', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
       data.parameters = JSON.stringify({ param: 'value' });
     });
@@ -79,7 +79,7 @@ describe('encoding incorrect params', () => {
     expect(goRes.error).toEqual(new EncodedEvmScriptError('parameters', 'Make sure parameters is a valid JSON array'));
   });
 
-  it('wrong number of parameters', async () => {
+  test('wrong number of parameters', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
       data.parameters = JSON.stringify(['arg1']);
     });
@@ -92,7 +92,7 @@ describe('encoding incorrect params', () => {
     );
   });
 
-  it('zero length parameters with non-empty target signature', async () => {
+  test('zero length parameters with non-empty target signature', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
       data.parameters = '[]';
     });
@@ -105,7 +105,7 @@ describe('encoding incorrect params', () => {
     );
   });
 
-  it('empty parameters with non-empty target signature', async () => {
+  test('empty parameters with non-empty target signature', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
       data.parameters = '';
     });
@@ -114,21 +114,6 @@ describe('encoding incorrect params', () => {
 
     assertGoError(goRes);
     expect(goRes.error).toEqual(new EncodedEvmScriptError('parameters', 'Make sure parameters is a valid JSON array'));
-  });
-
-  it('zero value for simple ETH transfer', async () => {
-    const invalidData = updateImmutably(newFormData, (data) => {
-      data.parameters = '[]';
-      data.targetSignature = '';
-      data.targetValue = '0';
-    });
-
-    const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
-
-    assertGoError(goRes);
-    expect(goRes.error).toEqual(
-      new EncodedEvmScriptError('targetValue', 'Value must be greater than 0 for ETH transfers')
-    );
   });
 
   it('throws when address is not a string', async () => {
@@ -144,6 +129,21 @@ describe('encoding incorrect params', () => {
       new EncodedEvmScriptError('parameters', 'Ensure parameters match target contract signature')
     );
   });
+});
+
+test('zero value for simple ETH transfer', async () => {
+  const invalidData = updateImmutably(newFormData, (data) => {
+    data.parameters = '[]';
+    data.targetSignature = '';
+    data.targetValue = '0';
+  });
+
+  const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
+
+  assertGoError(goRes);
+  expect(goRes.error).toEqual(
+    new EncodedEvmScriptError('targetValue', 'Value must be greater than 0 for ETH transfers')
+  );
 });
 
 describe('encoding invalid target signature', () => {
@@ -199,7 +199,7 @@ describe('address validation', () => {
     expect(goRes.error).toEqual(new EncodedEvmScriptError('targetAddress', 'Please specify a valid account address'));
   });
 
-  it('empty address', async () => {
+  test('empty address', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
       data.targetAddress = '';
     });
@@ -210,7 +210,7 @@ describe('address validation', () => {
     expect(goRes.error).toEqual(new EncodedEvmScriptError('targetAddress', 'Please specify a valid account address'));
   });
 
-  it('zero address is fine', async () => {
+  test('zero address', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
       data.targetAddress = constants.AddressZero;
     });

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -42,9 +42,9 @@ test('correct encoding', async () => {
   expect(goRes.data).toBeDefined();
 });
 
-it('allows simple ETH transfers using empty parameters and target signature', async () => {
+it('allows simple ETH transfers using zero length parameters and empty target signature', async () => {
   const validData = updateImmutably(newFormData, (data) => {
-    data.parameters = '';
+    data.parameters = '[]';
     data.targetSignature = '';
   });
 
@@ -92,9 +92,9 @@ describe('encoding incorrect params', () => {
     );
   });
 
-  it('empty parameters with non-empty target signature', async () => {
+  it('zero length parameters with non-empty target signature', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
-      data.parameters = '';
+      data.parameters = '[]';
     });
 
     const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
@@ -105,9 +105,20 @@ describe('encoding incorrect params', () => {
     );
   });
 
-  it('zero value for simple ETH transfer', async () => {
+  it('empty parameters with non-empty target signature', async () => {
     const invalidData = updateImmutably(newFormData, (data) => {
       data.parameters = '';
+    });
+
+    const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
+
+    assertGoError(goRes);
+    expect(goRes.error).toEqual(new EncodedEvmScriptError('parameters', 'Make sure parameters is a valid JSON array'));
+  });
+
+  it('zero value for simple ETH transfer', async () => {
+    const invalidData = updateImmutably(newFormData, (data) => {
+      data.parameters = '[]';
       data.targetSignature = '';
       data.targetValue = '0';
     });
@@ -117,20 +128,6 @@ describe('encoding incorrect params', () => {
     assertGoError(goRes);
     expect(goRes.error).toEqual(
       new EncodedEvmScriptError('targetValue', 'Value must be greater than 0 for ETH transfers')
-    );
-  });
-
-  it('empty array parameters ("[]") for simple ETH transfer', async () => {
-    const invalidData = updateImmutably(newFormData, (data) => {
-      data.parameters = '[]';
-      data.targetSignature = '';
-    });
-
-    const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
-
-    assertGoError(goRes);
-    expect(goRes.error).toEqual(
-      new EncodedEvmScriptError('parameters', 'Please specify an empty string for parameters for simple ETH transfer')
     );
   });
 });
@@ -171,7 +168,7 @@ describe('encoding invalid target signature', () => {
 
     assertGoError(goRes);
     expect(goRes.error).toEqual(
-      new EncodedEvmScriptError('parameters', 'Please specify an empty string for parameters for simple ETH transfer')
+      new EncodedEvmScriptError('parameters', 'Please specify the correct number of function arguments')
     );
   });
 });
@@ -350,11 +347,11 @@ describe('isEvmScriptValid()', () => {
   // The data for this proposal ware created locally.
   it('returns true also for simple ETH transfers', async () => {
     const script =
-      '0x00000001e0786c9956480b64808494676911f0afe39f8baa000000a4b61d27f60000000000000000000000001ddfc105fb187131ab6d77eecb966f87a2efa66400000000000000000000000000000000000000000000000000000000000005dc00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000004c5d2460100000000000000000000000000000000000000000000000000000000';
+      '0x00000001e0786c9956480b64808494676911f0afe39f8baa000000a4b61d27f60000000000000000000000001ddfc105fb187131ab6d77eecb966f87a2efa6640000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000004c5d2460100000000000000000000000000000000000000000000000000000000';
     const metadata = {
-      description: 'Send some ETH',
+      description: 'Send ETH to an EOA',
       targetSignature: '',
-      title: 'Send to Emik',
+      title: 'Make a simple ETH transfer proposal',
       version: '1',
     };
     const decodedEvmScript = await decodeEvmScript(mockedProvider, script, metadata);

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -104,6 +104,21 @@ describe('encoding incorrect params', () => {
       new EncodedEvmScriptError('parameters', 'Please specify the correct number of function arguments')
     );
   });
+
+  it('zero value for simple ETH transfer', async () => {
+    const invalidData = updateImmutably(newFormData, (data) => {
+      data.parameters = '';
+      data.targetSignature = '';
+      data.targetValue = '0';
+    });
+
+    const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
+
+    assertGoError(goRes);
+    expect(goRes.error).toEqual(
+      new EncodedEvmScriptError('targetValue', 'Value must be greater than 0 for ETH transfers')
+    );
+  });
 });
 
 describe('encoding invalid target signature', () => {

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -130,6 +130,20 @@ describe('encoding incorrect params', () => {
       new EncodedEvmScriptError('targetValue', 'Value must be greater than 0 for ETH transfers')
     );
   });
+
+  it('throws when address is not a string', async () => {
+    const invalidData = updateImmutably(newFormData, (data) => {
+      data.targetSignature = 'functionName(address)';
+      data.parameters = JSON.stringify([123]);
+    });
+
+    const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
+
+    assertGoError(goRes);
+    expect(goRes.error).toEqual(
+      new EncodedEvmScriptError('parameters', 'Ensure parameters match target contract signature')
+    );
+  });
 });
 
 describe('encoding invalid target signature', () => {

--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -43,12 +43,12 @@ test('correct encoding', async () => {
 });
 
 it('allows simple ETH transfers using empty parameters and target signature', async () => {
-  const invalidData = updateImmutably(newFormData, (data) => {
+  const validData = updateImmutably(newFormData, (data) => {
     data.parameters = '';
     data.targetSignature = '';
   });
 
-  const goRes = await goEncodeEvmScript(mockedProvider, invalidData, api3Agent);
+  const goRes = await goEncodeEvmScript(mockedProvider, validData, api3Agent);
 
   assertGoSuccess(goRes);
   expect(goRes.data).toBeDefined();

--- a/src/logic/proposals/encoding/encoding.ts
+++ b/src/logic/proposals/encoding/encoding.ts
@@ -68,9 +68,8 @@ export const goEncodeEvmScript = async (
   formData: NewProposalFormData,
   api3Agent: Api3Agent
 ): Promise<GoResult<string, EncodedEvmScriptError>> => {
-  // Ensure that the form parameters form a valid JSON array or an empty string (in case of a simple ETH transfer)
+  // Ensure that the form parameters form a valid JSON array
   const goJsonParams = goSync(() => {
-    if (!formData.parameters) return formData.parameters;
     const json = JSON.parse(formData.parameters);
     if (!Array.isArray(json)) throw new Error('Parameters must be an array');
     return json as unknown[];
@@ -91,13 +90,6 @@ export const goEncodeEvmScript = async (
     return fail(new EncodedEvmScriptError('targetSignature', 'Please specify a valid contract signature'));
   }
   const targetSignature = formData.targetSignature;
-
-  // Ensure parameters are empty string in case of simple ETH transfers
-  if (!targetSignature && (typeof targetParameters !== 'string' || targetParameters.length > 0)) {
-    return fail(
-      new EncodedEvmScriptError('parameters', 'Please specify an empty string for parameters for simple ETH transfer')
-    );
-  }
 
   // Extract the parameters that were passed and check if the number of arguments is same as in the function signature
   const goExtractParameters = goSync(() => {
@@ -240,7 +232,7 @@ export const decodeEvmScript = async (
       return {
         targetAddress: targetContractAddress,
         value,
-        parameters: null,
+        parameters: [],
       };
     }
 
@@ -290,7 +282,7 @@ export async function isEvmScriptValid(
       targetSignature: metadata.targetSignature ?? '',
       description: metadata.description,
       title: metadata.title,
-      parameters: decodedEvmScript.parameters === null ? '' : JSON.stringify(decodedEvmScript.parameters),
+      parameters: JSON.stringify(decodedEvmScript.parameters),
       targetAddress: decodedEvmScript.targetAddress,
       targetValue: decodedEvmScript.value.toString(),
     },

--- a/src/logic/proposals/encoding/encoding.ts
+++ b/src/logic/proposals/encoding/encoding.ts
@@ -148,12 +148,13 @@ export const goEncodeEvmScript = async (
 
   // Ensure value is a non-negative amount (in Wei)
   const goValue = goSync(() => {
-    const parsed = BigNumber.from(formData.targetValue);
-    if (parsed.lt(0)) throw new Error();
-    return parsed;
+    const goParsed = goSync(() => BigNumber.from(formData.targetValue));
+    if (!goParsed.success || goParsed.data.lt(0)) throw new Error('Please enter a valid amount in Wei');
+    if (!targetSignature && goParsed.data.eq(0)) throw new Error('Value must be greater than 0 for ETH transfers');
+    return goParsed.data;
   });
   if (!goValue.success) {
-    return fail(new EncodedEvmScriptError('targetValue', 'Please enter a valid amount in Wei'));
+    return fail(new EncodedEvmScriptError('targetValue', goValue.error.message));
   }
   const targetValue = goValue.data;
 

--- a/src/logic/proposals/encoding/encoding.ts
+++ b/src/logic/proposals/encoding/encoding.ts
@@ -73,7 +73,7 @@ export const goEncodeEvmScript = async (
     if (!formData.parameters) return formData.parameters;
     const json = JSON.parse(formData.parameters);
     if (!Array.isArray(json)) throw new Error('Parameters must be an array');
-    return json as string[];
+    return json as unknown[];
   });
   if (!goJsonParams.success) {
     return fail(new EncodedEvmScriptError('parameters', 'Make sure parameters is a valid JSON array'));
@@ -118,6 +118,7 @@ export const goEncodeEvmScript = async (
       range(parameterTypes.length).map(async (i) => {
         const param = targetParameters[i]!;
         if (parameterTypes[i] !== 'address') return param;
+        if (typeof param !== 'string') throw new Error('Parameter must be an ENS string');
 
         return convertToAddressOrThrow(provider, param);
       })

--- a/src/logic/proposals/encoding/encoding.ts
+++ b/src/logic/proposals/encoding/encoding.ts
@@ -92,6 +92,13 @@ export const goEncodeEvmScript = async (
   }
   const targetSignature = formData.targetSignature;
 
+  // Ensure parameters are empty string in case of simple ETH transfers
+  if (!targetSignature && (typeof targetParameters !== 'string' || targetParameters.length > 0)) {
+    return fail(
+      new EncodedEvmScriptError('parameters', 'Please specify an empty string for parameters for simple ETH transfer')
+    );
+  }
+
   // Extract the parameters that were passed and check if the number of arguments is same as in the function signature
   const goExtractParameters = goSync(() => {
     // Extract the parameter types from the target function signature

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -253,14 +253,12 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
                 <p className={globalStyles.secondaryColor}>{value.toString()}</p>
               </div>
             )}
-            {parameters !== null && (
-              <div className={styles.proposalDetailsItem}>
-                <p className={globalStyles.bold}>Parameters</p>
-                <p className={classNames(globalStyles.secondaryColor, styles.multiline)}>
-                  {JSON.stringify(parameters, null, 2)}
-                </p>
-              </div>
-            )}
+            <div className={styles.proposalDetailsItem}>
+              <p className={globalStyles.bold}>Parameters</p>
+              <p className={classNames(globalStyles.secondaryColor, styles.multiline)}>
+                {JSON.stringify(parameters, null, 2)}
+              </p>
+            </div>
           </div>
         }
         noMobileBorders

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -241,22 +241,26 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
                 )}
               </p>
             </div>
-            <div className={styles.proposalDetailsItem}>
-              <p className={globalStyles.bold}>Target Contract Signature</p>
-              <p className={globalStyles.secondaryColor}>{proposal.metadata.targetSignature}</p>
-            </div>
+            {proposal.metadata.targetSignature && (
+              <div className={styles.proposalDetailsItem}>
+                <p className={globalStyles.bold}>Target Contract Signature</p>
+                <p className={globalStyles.secondaryColor}>{proposal.metadata.targetSignature}</p>
+              </div>
+            )}
             {value.gt(0) && (
               <div className={styles.proposalDetailsItem}>
                 <p className={globalStyles.bold}>Value (Wei)</p>
                 <p className={globalStyles.secondaryColor}>{value.toString()}</p>
               </div>
             )}
-            <div className={styles.proposalDetailsItem}>
-              <p className={globalStyles.bold}>Parameters</p>
-              <p className={classNames(globalStyles.secondaryColor, styles.multiline)}>
-                {JSON.stringify(parameters, null, 2)}
-              </p>
-            </div>
+            {parameters !== null && (
+              <div className={styles.proposalDetailsItem}>
+                <p className={globalStyles.bold}>Parameters</p>
+                <p className={classNames(globalStyles.secondaryColor, styles.multiline)}>
+                  {JSON.stringify(parameters, null, 2)}
+                </p>
+              </div>
+            )}
           </div>
         }
         noMobileBorders

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -230,7 +230,7 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
               </p>
             </div>
             <div className={styles.proposalDetailsItem}>
-              <p className={globalStyles.bold}>Target Contract Address</p>
+              <p className={globalStyles.bold}>Target Address</p>
               <p className={classNames(globalStyles.secondaryColor, styles.address)}>
                 {urlTargetAddress ? (
                   <ExternalLink className={styles.link} href={urlTargetAddress}>

--- a/src/pages/proposal-commons/treasury/treasury.tsx
+++ b/src/pages/proposal-commons/treasury/treasury.tsx
@@ -20,6 +20,7 @@ const TreasuryDropdown = (props: TreasuryDropdownProps) => {
   const agentAddresses = useApi3AgentAddresses();
   const etherscanExplainer = `Etherscan link for the ${type} DAO agent`;
   const agentAddress = agentAddresses?.[type];
+  const etherscanAddressUrl = agentAddress && getEtherscanAddressUrl(chainId, agentAddress);
 
   return (
     <Dropdown
@@ -42,10 +43,10 @@ const TreasuryDropdown = (props: TreasuryDropdownProps) => {
         >
           {type}
         </p>
-        {agentAddress && (
+        {etherscanAddressUrl && (
           <span className={classNames(styles.copy, globalStyles.textSmall)}>
             <Tooltip overlay={etherscanExplainer}>
-              <ExternalLink href={getEtherscanAddressUrl(chainId, agentAddress) ?? ''} className={styles.dropdownLink}>
+              <ExternalLink href={etherscanAddressUrl} className={styles.dropdownLink}>
                 <img
                   src={images.externalLink}
                   alt={etherscanExplainer}

--- a/src/pages/proposals/forms/new-proposal-form.tsx
+++ b/src/pages/proposals/forms/new-proposal-form.tsx
@@ -127,7 +127,7 @@ const NewProposalForm = (props: Props) => {
       </ProposalFormItem>
 
       <ProposalFormItem
-        name={<label htmlFor="target-address">Target Contract Address</label>}
+        name={<label htmlFor="target-address">Target Address</label>}
         tooltip="The address of the contract you want to be called when the proposal is executed."
       >
         <Input id="target-address" value={targetAddress} onChange={(e) => setTargetAddress(e.target.value)} block />


### PR DESCRIPTION
See: https://api3workspace.slack.com/archives/C02ALA11APM/p1683621470320789

## Rationale

Review commit by commit.

Initially, we used only a very loose validation of the proposal form. Later we improved this, but we also prevented a use case of simple ETH transfer. 

To support this use case, I've added special cases to the validation. If both target contract signature and parameters are empty, the validation passes and a proposal can be created. Since signature and parameters can be empty now, I think it makes sense to hide them in proposal details.

I've tested it manually locally, but creating e2e is complex so I opted for encoding unit tests only.

## Images

1. I filled the proposal form
<img width="755" alt="image" src="https://github.com/api3dao/api3-dao-dashboard/assets/22679154/0f361278-ba0e-4e74-a0cc-90a5af8d8d2a">

2. After creating it, it got immediately executed (since I have all the voting power)
<img width="847" alt="image" src="https://github.com/api3dao/api3-dao-dashboard/assets/22679154/5d7c2364-00f3-41c0-8c89-cc6aa3816e40">

3. Proposal details
<img width="847" alt="image" src="https://github.com/api3dao/api3-dao-dashboard/assets/22679154/4ad0656c-9e27-4b18-a86e-7d1fcb5884a2">
