### PR TITLE
Add tests around encoding ENS names back in

### DIFF
--- a/src/logic/proposals/encoding/encoding.test.ts
+++ b/src/logic/proposals/encoding/encoding.test.ts
@@ -245,6 +245,39 @@ test('decoding', async () => {
 });
 
 describe('ENS name support', () => {
+  it('supports ENS name in target address', async () => {
+    const formDataWithAddress = updateImmutably(newFormData, (data) => {
+      data.targetAddress = MOCKED_ENS_ENTRY.ensName;
+    });
+
+    const goRes = await goEncodeEvmScript(mockedProvider, formDataWithAddress, api3Agent);
+    const metadata = decodeMetadata(encodeMetadata(formDataWithAddress))!;
+
+    assertGoSuccess(goRes);
+    expect(await decodeEvmScript(mockedProvider, goRes.data, metadata)).toEqual({
+      targetAddress: MOCKED_ENS_ENTRY.address,
+      value: BigNumber.from('12'),
+      parameters: ['arg1', '123'],
+    });
+  });
+
+  it('supports ENS names in parameters', async () => {
+    const formDataWithAddress = updateImmutably(newFormData, (data) => {
+      data.targetSignature = 'functionName(address)';
+      data.parameters = JSON.stringify([MOCKED_ENS_ENTRY.ensName]);
+    });
+
+    const goRes = await goEncodeEvmScript(mockedProvider, formDataWithAddress, api3Agent);
+    const metadata = decodeMetadata(encodeMetadata(formDataWithAddress))!;
+
+    assertGoSuccess(goRes);
+    expect(await decodeEvmScript(mockedProvider, goRes.data, metadata)).toEqual({
+      targetAddress: '0xB97F3A052d5562437e42EDeEBd1afec2376666eD',
+      value: BigNumber.from('12'),
+      parameters: [MOCKED_ENS_ENTRY.address],
+    });
+  });
+
   it('supports addresses in parameters', async () => {
     const address = '0x4017F39E438ADA9F860E15030E6A6e4b7b1af8Ba';
     const formDataWithAddress = updateImmutably(newFormData, (data) => {


### PR DESCRIPTION
#401 

### What does this change?
It adds the tests back that was removed as part of the web3modal upgrade here: https://github.com/api3dao/api3-dao-dashboard/commit/d203177610586429f9b7fb3978156d295230eb6f#diff-d007a916315fd637a98142838e0bff7a8336ac91e5d2210aa5e50cb0d0915408L248

I have realised that we don't need to remove them completely, but that they should be adjusted.