### PR TITLE
Use v2 wallet connector (Wallet Connect)

### DIFF
--- a/src/contracts/hooks.ts
+++ b/src/contracts/hooks.ts
@@ -11,34 +11,54 @@ import {
 } from './artifacts/factories';
 import { initialChainData } from '../chain-data/state';
 
+const useContractReader = () => {
+  const { contracts, provider, signer } = useChainData();
+  const { connector } = useAccount();
+
+  /*
+   * Please note the following:
+   * 1. When connected via non-MetaMask wallets (like via Wallet Connect), loading contract data fails when
+   *    the smart contract was constructed with a signer.
+   * 2. Data loads a considerable amount faster with MetaMask when using the signer.
+   *
+   * In conclusion, we want to use the provider when connecting the contracts, except when we are connected via
+   * MetaMask (and aren't running the app locally).
+   */
+  const reader = connector?.name === 'MetaMask' && process.env.NODE_ENV !== 'development' ? signer : provider;
+  return {
+    contracts,
+    reader,
+  };
+};
+
 export const useApi3Pool = () => {
-  const { contracts, signer } = useChainData();
+  const { contracts, reader } = useContractReader();
 
   return useMemo(() => {
-    if (!contracts || !signer) return null;
-    return Api3PoolFactory.connect(contracts.api3Pool, signer);
-  }, [signer, contracts]);
+    if (!contracts || !reader) return null;
+    return Api3PoolFactory.connect(contracts.api3Pool, reader);
+  }, [reader, contracts]);
 };
 
 export const useApi3Token = () => {
-  const { contracts, signer } = useChainData();
+  const { contracts, reader } = useContractReader();
 
   return useMemo(() => {
-    if (!contracts || !signer) return null;
-    return Api3TokenFactory.connect(contracts.api3Token, signer);
-  }, [signer, contracts]);
+    if (!contracts || !reader) return null;
+    return Api3TokenFactory.connect(contracts.api3Token, reader);
+  }, [reader, contracts]);
 };
 
 export const useApi3Voting = () => {
-  const { contracts, signer } = useChainData();
+  const { contracts, reader } = useContractReader();
 
   return useMemo(() => {
-    if (!contracts || !signer) return null;
+    if (!contracts || !reader) return null;
     return {
-      primary: Api3VotingFactory.connect(contracts.votingAppPrimary, signer),
-      secondary: Api3VotingFactory.connect(contracts.votingAppSecondary, signer),
+      primary: Api3VotingFactory.connect(contracts.votingAppPrimary, reader),
+      secondary: Api3VotingFactory.connect(contracts.votingAppSecondary, reader),
     };
-  }, [signer, contracts]);
+  }, [reader, contracts]);
 };
 
 export interface Api3Agent {
@@ -59,23 +79,23 @@ export const useApi3AgentAddresses = (): Api3Agent | null => {
 };
 
 export const useConvenience = () => {
-  const { contracts, signer } = useChainData();
+  const { contracts, reader } = useContractReader();
 
   return useMemo(() => {
-    if (!contracts || !signer) return null;
+    if (!contracts || !reader) return null;
 
-    return ConvenienceFactory.connect(contracts.convenience, signer);
-  }, [signer, contracts]);
+    return ConvenienceFactory.connect(contracts.convenience, reader);
+  }, [reader, contracts]);
 };
 
 export const useTimelockManager = () => {
-  const { signer, contracts } = useChainData();
+  const { contracts, reader } = useContractReader();
 
   return useMemo(() => {
-    if (!contracts || !signer) return null;
+    if (!contracts || !reader) return null;
 
-    return TimelockManagerFactory.connect(contracts.timelockManager, signer);
-  }, [signer, contracts]);
+    return TimelockManagerFactory.connect(contracts.timelockManager, reader);
+  }, [reader, contracts]);
 };
 
 export const useProviderSubscriptions = () => {

--- a/src/pages/dashboard/dashboard.tsx
+++ b/src/pages/dashboard/dashboard.tsx
@@ -22,7 +22,7 @@ import classNames from 'classnames';
 type ModalType = 'deposit' | 'withdraw' | 'stake' | 'unstake' | 'confirm-unstake';
 
 const Dashboard = () => {
-  const { dashboardState: data, transactions, setChainData, provider } = useChainData();
+  const { dashboardState: data, transactions, setChainData, signer, provider } = useChainData();
   const api3Pool = useApi3Pool();
 
   useLoadDashboardData();
@@ -155,7 +155,7 @@ const Dashboard = () => {
           onConfirm={async (parsedValue: BigNumber) => {
             if (!api3Pool) return;
 
-            const tx = await handleTransactionError(api3Pool.withdrawRegular(parsedValue));
+            const tx = await handleTransactionError(api3Pool.connect(signer!).withdrawRegular(parsedValue));
             if (tx) {
               setChainData('Save withdraw transaction', { transactions: [...transactions, { type: 'withdraw', tx }] });
             }
@@ -173,7 +173,7 @@ const Dashboard = () => {
           onConfirm={async (parsedValue: BigNumber) => {
             if (!api3Pool) return;
 
-            const tx = await handleTransactionError(api3Pool.stake(parsedValue));
+            const tx = await handleTransactionError(api3Pool.connect(signer!).stake(parsedValue));
             if (tx) {
               setChainData('Save stake transaction', { transactions: [...transactions, { type: 'stake', tx }] });
             }
@@ -205,7 +205,7 @@ const Dashboard = () => {
             onConfirm={async (parsedValue: BigNumber) => {
               if (!api3Pool || !data) return;
 
-              const tx = await handleTransactionError(api3Pool.scheduleUnstake(parsedValue));
+              const tx = await handleTransactionError(api3Pool.connect(signer!).scheduleUnstake(parsedValue));
               if (tx) {
                 setChainData('Save initiate unstake transaction', {
                   transactions: [...transactions, { type: 'initiate-unstake', tx }],

--- a/src/pages/dashboard/forms/token-deposit-form.tsx
+++ b/src/pages/dashboard/forms/token-deposit-form.tsx
@@ -21,7 +21,7 @@ interface Props {
 const TokenDepositForm = (props: Props) => {
   const { allowance, walletBalance } = props;
 
-  const { setChainData, transactions, userAccount } = useChainData();
+  const { signer, setChainData, transactions, userAccount } = useChainData();
   const api3Token = useApi3Token();
   const api3Pool = useApi3Pool();
 
@@ -36,7 +36,7 @@ const TokenDepositForm = (props: Props) => {
 
     setError('');
 
-    const goResponse = await go(api3Token.approve(api3Pool.address, MAX_ALLOWANCE));
+    const goResponse = await go(api3Token.connect(signer!).approve(api3Pool.address, MAX_ALLOWANCE));
     if (goResponse.success) {
       const tx = goResponse.data;
       setChainData('Save deposit approval', { transactions: [...transactions, { type: 'approve-deposit', tx }] });
@@ -66,7 +66,7 @@ const TokenDepositForm = (props: Props) => {
     setError('');
 
     const methodName = type === 'deposit-only' ? 'depositRegular' : 'depositAndStake';
-    const goResponse = await go(api3Pool[methodName](parsedInput));
+    const goResponse = await go(api3Pool.connect(signer!)[methodName](parsedInput));
     if (goResponse.success) {
       const tx = goResponse.data;
       setChainData(`Save "${type}" transaction`, { transactions: [...transactions, { type, tx }] });

--- a/src/pages/dashboard/pending-unstake-panel/pending-unstake-panel.tsx
+++ b/src/pages/dashboard/pending-unstake-panel/pending-unstake-panel.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 const PendingUnstakePanel = (props: Props) => {
   const api3Pool = useApi3Pool();
-  const { transactions, setChainData, userAccount } = useChainData();
+  const { signer, transactions, setChainData, userAccount } = useChainData();
 
   const { amount, canUnstake, canUnstakeAndWithdraw, unstakeDate } = props;
   const [timerDays, setTimerDays] = useState('0');
@@ -60,7 +60,7 @@ const PendingUnstakePanel = (props: Props) => {
 
   const handleUnstake = async () => {
     if (!api3Pool) return;
-    const tx = await handleTransactionError(api3Pool.unstake(userAccount));
+    const tx = await handleTransactionError(api3Pool.connect(signer!).unstake(userAccount));
     if (tx) {
       setChainData('Save unstake transaction', { transactions: [...transactions, { type: 'unstake', tx }] });
     }
@@ -68,7 +68,7 @@ const PendingUnstakePanel = (props: Props) => {
 
   const handleUnstakeAndWithdraw = async () => {
     if (!api3Pool) return;
-    const tx = await handleTransactionError(api3Pool.unstakeAndWithdraw());
+    const tx = await handleTransactionError(api3Pool.connect(signer!).unstakeAndWithdraw());
     if (tx) {
       setChainData('Save unstake and Withdraw transaction', {
         transactions: [...transactions, { type: 'unstake-withdraw', tx }],

--- a/src/pages/dashboard/unstake-banner/unstake-banner.tsx
+++ b/src/pages/dashboard/unstake-banner/unstake-banner.tsx
@@ -13,11 +13,11 @@ interface Props {
 const UnstakeBanner = (props: Props) => {
   const { canUnstakeAndWithdraw } = props;
   const api3Pool = useApi3Pool();
-  const { setChainData, transactions, userAccount } = useChainData();
+  const { signer, setChainData, transactions, userAccount } = useChainData();
 
   const handleUnstake = async () => {
     if (!api3Pool) return;
-    const tx = await handleTransactionError(api3Pool.unstake(userAccount));
+    const tx = await handleTransactionError(api3Pool.connect(signer!).unstake(userAccount));
     if (tx) {
       setChainData('Save unstake transaction', { transactions: [...transactions, { type: 'unstake', tx }] });
     }
@@ -25,7 +25,7 @@ const UnstakeBanner = (props: Props) => {
 
   const handleUnstakeAndWithdraw = async () => {
     if (!api3Pool) return;
-    const tx = await handleTransactionError(api3Pool.unstakeAndWithdraw());
+    const tx = await handleTransactionError(api3Pool.connect(signer!).unstakeAndWithdraw());
     if (tx) {
       setChainData('Save unstake and Withdraw transaction', {
         transactions: [...transactions, { type: 'unstake-withdraw', tx }],

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -90,7 +90,7 @@ interface ProposalDetailsProps {
 }
 
 const ProposalDetailsContent = (props: ProposalDetailsProps) => {
-  const { chainId } = useChainData();
+  const { chainId, signer } = useChainData();
   const { proposal } = props;
   const isMalicious = useMaliciousProposalCheck(typeof proposal === 'string' ? null : proposal);
   const [voteModalOpen, setVoteModalOpen] = useState(false);
@@ -195,7 +195,7 @@ const ProposalDetailsContent = (props: ProposalDetailsProps) => {
             onConfirm={async (choice) => {
               setVoteModalOpen(false);
               const tx = await handleTransactionError(
-                voting[proposal.type].vote(proposal.voteId, choice === 'for', true)
+                voting[proposal.type].connect(signer!).vote(proposal.voteId, choice === 'for', true)
               );
               const type = choice === 'for' ? 'vote-for' : 'vote-against';
               if (tx) {

--- a/src/pages/proposal-commons/proposal-list/proposal-status/proposal-status.tsx
+++ b/src/pages/proposal-commons/proposal-list/proposal-status/proposal-status.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 const ProposalStatus = (props: Props) => {
   const voting = useApi3Voting();
-  const { setChainData } = useChainData();
+  const { signer, setChainData } = useChainData();
   const { proposal, large } = props;
   const proposalStatus = voteSliderSelector(proposal).proposalStatus;
 
@@ -48,7 +48,9 @@ const ProposalStatus = (props: Props) => {
           className={styles.execute}
           onClick={async () => {
             if (!voting) return;
-            const tx = await handleTransactionError(voting[proposal.type].executeVote(proposal.voteId));
+            const tx = await handleTransactionError(
+              voting[proposal.type].connect(signer!).executeVote(proposal.voteId)
+            );
             if (tx) {
               setChainData('Save execute transaction', (state) => ({
                 transactions: [...state.transactions, { type: 'execute', tx }],

--- a/src/pages/proposals/delegation/delegation.tsx
+++ b/src/pages/proposals/delegation/delegation.tsx
@@ -16,7 +16,7 @@ import classNames from 'classnames';
 
 const Delegation = () => {
   // TODO: Retrieve only "userStaked" from the chain instead of loading all staking data (and remove useLoadDashboardData call)
-  const { delegation, dashboardState, setChainData, transactions } = useChainData();
+  const { signer, delegation, dashboardState, setChainData, transactions } = useChainData();
   const api3Pool = useApi3Pool();
 
   const [openDelegationModal, setOpenDelegationModal] = useState(false);
@@ -65,7 +65,7 @@ const Delegation = () => {
               onUndelegate={async () => {
                 if (!api3Pool) return;
 
-                const tx = await handleTransactionError(api3Pool.undelegateVotingPower());
+                const tx = await handleTransactionError(api3Pool.connect(signer!).undelegateVotingPower());
                 if (tx) {
                   setChainData('Save undelegate transaction', {
                     transactions: [...transactions, { type: 'undelegate', tx }],

--- a/src/pages/proposals/forms/delegate/delegate-form.tsx
+++ b/src/pages/proposals/forms/delegate/delegate-form.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 const DelegateVotesForm = (props: Props) => {
   const { onClose } = props;
-  const { setChainData, transactions, userAccount, provider } = useChainData();
+  const { setChainData, transactions, userAccount, signer, provider } = useChainData();
 
   const [error, setError] = useState('');
   const [delegationAddress, setDelegationAddress] = useState('');
@@ -55,7 +55,7 @@ const DelegateVotesForm = (props: Props) => {
       return setError(messages.REDELEGATION_IS_FORBIDDEN(targetDelegate));
     }
 
-    const tx = await handleTransactionError(api3Pool.delegateVotingPower(delegationTarget));
+    const tx = await handleTransactionError(api3Pool.connect(signer!).delegateVotingPower(delegationTarget));
     if (tx) {
       setChainData('Save delegate transaction', { transactions: [...transactions, { type: 'delegate', tx }] });
     }

--- a/src/pages/proposals/proposals.tsx
+++ b/src/pages/proposals/proposals.tsx
@@ -25,7 +25,7 @@ import styles from './proposals.module.scss';
 
 const Proposals = () => {
   // TODO: Retrieve only "userVotingPower" from the chain instead of loading all staking data (and remove useLoadDashboardData call)
-  const { provider, proposals, delegation, dashboardState, isGenesisEpoch, transactions, setChainData } =
+  const { signer, provider, proposals, delegation, dashboardState, isGenesisEpoch, transactions, setChainData } =
     useChainData();
   const api3Voting = useApi3Voting();
   const api3Token = useApi3Token();
@@ -95,7 +95,9 @@ const Proposals = () => {
 
     const tx = await handleTransactionError(
       // NOTE: For some reason only this 'ugly' version is available on the contract
-      api3Voting[formData.type]['newVote(bytes,string,bool,bool)'](goRes.data, encodeMetadata(formData), true, true)
+      api3Voting[formData.type]
+        .connect(signer!)
+        ['newVote(bytes,string,bool,bool)'](goRes.data, encodeMetadata(formData), true, true)
     );
     if (tx) {
       setChainData('Save new vote transaction', { transactions: [...transactions, { type: 'new-vote', tx }] });

--- a/src/pages/vesting/vesting.tsx
+++ b/src/pages/vesting/vesting.tsx
@@ -7,7 +7,7 @@ import { handleTransactionError } from '../../utils';
 import styles from './vesting.module.scss';
 
 const Vesting = () => {
-  const { userAccount, setChainData, vesting } = useChainData();
+  const { signer, userAccount, setChainData, vesting } = useChainData();
   const timelockManager = useTimelockManager();
   const api3Pool = useApi3Pool();
 
@@ -23,7 +23,7 @@ const Vesting = () => {
           onClick={async () => {
             if (!api3Pool || !userAccount) return;
 
-            const tx = await handleTransactionError(api3Pool.updateTimelockStatus(userAccount));
+            const tx = await handleTransactionError(api3Pool.connect(signer!).updateTimelockStatus(userAccount));
             if (tx) {
               setChainData('Save update timelock status transaction', (state) => ({
                 transactions: [...state.transactions, { type: 'update-timelock-status', tx }],
@@ -38,7 +38,9 @@ const Vesting = () => {
           onClick={async () => {
             if (!timelockManager || !api3Pool) return;
 
-            const tx = await handleTransactionError(timelockManager.withdrawToPool(api3Pool.address, userAccount));
+            const tx = await handleTransactionError(
+              timelockManager.connect(signer!).withdrawToPool(api3Pool.address, userAccount)
+            );
             if (tx) {
               setChainData('Save withdraw to pool transaction', (state) => ({
                 transactions: [...state.transactions, { type: 'withdraw-to-pool', tx }],

--- a/src/wallet-connect.ts
+++ b/src/wallet-connect.ts
@@ -29,7 +29,7 @@ const { provider } = configureChains(chains, [
 
 export const wagmiClient = createClient({
   autoConnect: false,
-  connectors: w3mConnectors({ version: 1, chains, projectId }),
+  connectors: w3mConnectors({ version: 2, chains, projectId }),
   provider,
 });
 


### PR DESCRIPTION
### What does this change?
It bumps the Wallet Connect version to v2, but it wasn't as simple as updating the version from 1 to 2:
```diff
// src/wallet-connect.ts
-connectors: w3mConnectors({ version: 1, chains, projectId }),
+connectors: w3mConnectors({ version: 2, chains, projectId }),
```
It turns out, when using the v2 connector and you construct a smart contract with a `signer`, it fails when calling a method on the smart contract that loads data from the chain. **Note** this is when using a wallet (like Trust/Rainbow) via Wallet Connect, MetaMask works fine. To fix the data loading issue, it boils down to using the `provider` instead:
```diff
-ConvenienceFactory.connect(contracts.convenience, signer);
+ConvenienceFactory.connect(contracts.convenience, provider);
```
And connecting as the `signer` when creating transactions:
```diff
-api3Pool.stake(parsedValue))
+api3Pool.connect(signer).stake(parsedValue))
```

I managed to reproduce the error and I opened a [discussion](https://github.com/orgs/WalletConnect/discussions/2694) to get feedback whether this is expected behaviour or not (I suspect it's expected behaviour).

#### Side Note
The Market had a [weird bug](https://github.com/orgs/WalletConnect/discussions/2673) with the v2 connector that forces us to upgrade the `wagmi` dependency to v1 (that uses `viem`). The DAO Dashboard doesn't have that bug, so I decided to keep the `wagmi` dependency as is (at least for now).