### PR TITLE
Update @api3/promise-utils

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 import { readFileSync, existsSync } from 'fs';
 
 export default defineConfig({
-  defaultCommandTimeout: 10000,
+  defaultCommandTimeout: 15000,
 
   retries: {
     runMode: 1,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "wagmi": "^0.12.13"
   },
   "devDependencies": {
-    "@api3/promise-utils": "^0.1.0",
+    "@api3/promise-utils": "0.3.0",
     "@nomiclabs/hardhat-ethers": "^2.0.4",
     "@percy/cli": "^1.6.0",
     "@percy/cypress": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "wagmi": "^0.12.13"
   },
   "devDependencies": {
-    "@api3/promise-utils": "0.3.0",
+    "@api3/promise-utils": "^0.4.0",
     "@nomiclabs/hardhat-ethers": "^2.0.4",
     "@percy/cli": "^1.6.0",
     "@percy/cypress": "^3.1.2",

--- a/src/chain-data/helpers.ts
+++ b/src/chain-data/helpers.ts
@@ -40,7 +40,7 @@ export const displayPendingTransaction = async (
     { autoClose: false, closeOnClick: false }
   );
 
-  const goRes = await go(transaction.wait());
+  const goRes = await go(() => transaction.wait());
   if (infoToastId) notifications.close(infoToastId);
 
   // NOTE: ethers.js adds various additional fields to Error, so it's easier to type as 'any'

--- a/src/logic/dashboard/hooks.ts
+++ b/src/logic/dashboard/hooks.ts
@@ -14,7 +14,7 @@ export const useLoadDashboardData = () => {
   const loadDashboardData = useCallback(async () => {
     if (!provider || !api3Pool || !api3Token || !convenience || !userAccount) return null;
 
-    const goStakingData = await go(convenience.getUserStakingData(userAccount));
+    const goStakingData = await go(() => convenience.getUserStakingData(userAccount));
     if (!goStakingData.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_CHAIN_DATA,
@@ -23,7 +23,7 @@ export const useLoadDashboardData = () => {
     }
     const stakingData = goStakingData.data;
 
-    const goAllowance = await go(api3Token.allowance(userAccount, api3Pool.address));
+    const goAllowance = await go(() => api3Token.allowance(userAccount, api3Pool.address));
     if (!goAllowance.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_CHAIN_DATA,

--- a/src/logic/proposals/encoding/encoding.ts
+++ b/src/logic/proposals/encoding/encoding.ts
@@ -67,7 +67,7 @@ export const goEncodeEvmScript = async (
   provider: providers.Provider,
   formData: NewProposalFormData,
   api3Agent: Api3Agent
-): Promise<GoResult<string, EncodedEvmScriptError>> => {
+): Promise<GoResult<string>> => {
   // Ensure that the form parameters form a valid JSON array
   const goJsonParams = goSync(() => {
     const json = JSON.parse(formData.parameters);

--- a/src/logic/proposals/encoding/ens-name.ts
+++ b/src/logic/proposals/encoding/ens-name.ts
@@ -26,7 +26,7 @@ export const convertToAddressOrThrow = async (provider: providers.Provider, ensN
 export const convertToEnsName = async (provider: providers.Provider, ensNameOrAddress: string) => {
   if (!utils.isAddress(ensNameOrAddress)) return null;
 
-  const goEnsName = await go(provider.lookupAddress(ensNameOrAddress));
+  const goEnsName = await go(() => provider.lookupAddress(ensNameOrAddress));
   if (!goEnsName.success) return null;
 
   return goEnsName.data;

--- a/src/logic/proposals/hooks/active-proposals.ts
+++ b/src/logic/proposals/hooks/active-proposals.ts
@@ -179,7 +179,7 @@ const useReloadActiveProposals = () => {
       }
     };
 
-    const goResponse = await go(loadProposals());
+    const goResponse = await go(() => loadProposals());
     if (!goResponse.success) {
       // TODO: error handling
       // eslint-disable-next-line no-console

--- a/src/logic/proposals/hooks/genesis-epoch.ts
+++ b/src/logic/proposals/hooks/genesis-epoch.ts
@@ -16,7 +16,7 @@ export const useLoadGenesisEpoch = () => {
   const loadIsGenesisEpoch = useCallback(async () => {
     if (!api3Pool) return null;
 
-    const goResponse = await go(api3Pool.isGenesisEpoch());
+    const goResponse = await go(() => api3Pool.isGenesisEpoch());
     if (!goResponse.success) {
       notifications.error({
         message: messages.FAILED_TO_LOAD_GENESIS_EPOCH,

--- a/src/logic/proposals/hooks/history-proposals.ts
+++ b/src/logic/proposals/hooks/history-proposals.ts
@@ -141,7 +141,7 @@ const useReloadHistoryProposals = () => {
       );
     };
 
-    const goResponse = await go(loadProposals());
+    const goResponse = await go(() => loadProposals());
     if (!goResponse.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_PROPOSALS,

--- a/src/logic/proposals/hooks/load-by-ids.ts
+++ b/src/logic/proposals/hooks/load-by-ids.ts
@@ -37,7 +37,7 @@ export const useProposalById = (type: ProposalType, id: BigNumber) => {
     const votingApp = api3Voting[type];
     const startVoteFilter = votingApp.filters.StartVote(id, null, null);
 
-    const goStartVoteFilters = await go(votingApp.queryFilter(startVoteFilter));
+    const goStartVoteFilters = await go(() => votingApp.queryFilter(startVoteFilter));
     if (!goStartVoteFilters.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_PROPOSALS,
@@ -62,7 +62,7 @@ export const useProposalById = (type: ProposalType, id: BigNumber) => {
       voteId: ethersArgs.voteId,
     };
 
-    const goOpenVoteIds = await go(convenience.getOpenVoteIds(VOTING_APP_IDS[type]));
+    const goOpenVoteIds = await go(() => convenience.getOpenVoteIds(VOTING_APP_IDS[type]));
     if (!goOpenVoteIds.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_PROPOSALS,
@@ -71,7 +71,9 @@ export const useProposalById = (type: ProposalType, id: BigNumber) => {
     }
     const openVoteIds = goOpenVoteIds.data;
 
-    const goLoadProposal = await go(getProposals(provider, convenience, userAccount, [startVote], openVoteIds, type));
+    const goLoadProposal = await go(() =>
+      getProposals(provider, convenience, userAccount, [startVote], openVoteIds, type)
+    );
     if (!goLoadProposal.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_PROPOSALS,
@@ -97,7 +99,7 @@ export const useProposalById = (type: ProposalType, id: BigNumber) => {
   const reloadProposalsByIds = useCallback(async () => {
     if (!convenience) return;
 
-    const goVotingData = await go(convenience.getDynamicVoteData(VOTING_APP_IDS[type], userAccount, [id]));
+    const goVotingData = await go(() => convenience.getDynamicVoteData(VOTING_APP_IDS[type], userAccount, [id]));
     if (!goVotingData.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_PROPOSALS,

--- a/src/logic/treasury-and-delegation/use-treasury-and-delegation.ts
+++ b/src/logic/treasury-and-delegation/use-treasury-and-delegation.ts
@@ -18,7 +18,7 @@ export const useTreasuryAndDelegation = () => {
     if (!api3Voting || !convenience || !provider) return;
 
     const loadTreasuryAndDelegation = async () => {
-      const goResponse = await go(convenience.getTreasuryAndUserDelegationData(userAccount));
+      const goResponse = await go(() => convenience.getTreasuryAndUserDelegationData(userAccount));
       assertGoSuccess(goResponse);
       const data = goResponse.data;
 

--- a/src/logic/vesting/hooks.ts
+++ b/src/logic/vesting/hooks.ts
@@ -13,7 +13,7 @@ export const useLoadVestingData = () => {
   const loadDashboardData = useCallback(async () => {
     if (!provider || !api3Pool || !timelockManager || !userAccount) return null;
 
-    const goVestingData = await go(api3Pool.getUser(userAccount));
+    const goVestingData = await go(() => api3Pool.getUser(userAccount));
     if (!goVestingData.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_VESTING_DATA,
@@ -22,7 +22,7 @@ export const useLoadVestingData = () => {
     }
     const vestingData = goVestingData.data;
 
-    const goTimelock = await go(timelockManager.getTimelock(userAccount));
+    const goTimelock = await go(() => timelockManager.getTimelock(userAccount));
     if (!goTimelock.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_VESTING_DATA,

--- a/src/pages/dashboard/forms/token-deposit-form.tsx
+++ b/src/pages/dashboard/forms/token-deposit-form.tsx
@@ -36,7 +36,7 @@ const TokenDepositForm = (props: Props) => {
 
     setError('');
 
-    const goResponse = await go(api3Token.connect(signer!).approve(api3Pool.address, MAX_ALLOWANCE));
+    const goResponse = await go(() => api3Token.connect(signer!).approve(api3Pool.address, MAX_ALLOWANCE));
     if (goResponse.success) {
       const tx = goResponse.data;
       setChainData('Save deposit approval', { transactions: [...transactions, { type: 'approve-deposit', tx }] });
@@ -66,7 +66,7 @@ const TokenDepositForm = (props: Props) => {
     setError('');
 
     const methodName = type === 'deposit-only' ? 'depositRegular' : 'depositAndStake';
-    const goResponse = await go(api3Pool.connect(signer!)[methodName](parsedInput));
+    const goResponse = await go(() => api3Pool.connect(signer!)[methodName](parsedInput));
     if (goResponse.success) {
       const tx = goResponse.data;
       setChainData(`Save "${type}" transaction`, { transactions: [...transactions, { type, tx }] });

--- a/src/pages/proposals/forms/delegate/delegate-form.tsx
+++ b/src/pages/proposals/forms/delegate/delegate-form.tsx
@@ -29,7 +29,7 @@ const DelegateVotesForm = (props: Props) => {
   const onDelegate = async () => {
     if (!api3Pool || !provider) return;
 
-    const goDelegationTargetResolvedName = await go(convertToAddressOrThrow(provider, delegationAddress));
+    const goDelegationTargetResolvedName = await go(() => convertToAddressOrThrow(provider, delegationAddress));
     const delegationTarget = goDelegationTargetResolvedName.success
       ? goDelegationTargetResolvedName.data
       : delegationAddress;
@@ -42,7 +42,7 @@ const DelegateVotesForm = (props: Props) => {
       return setError(messages.DELEGATE_IS_YOURSELF);
     }
 
-    const goDelegate = await go(api3Pool.userDelegate(delegationTarget));
+    const goDelegate = await go(() => api3Pool.userDelegate(delegationTarget));
     if (!goDelegate.success) {
       return notifications.error({
         message: messages.FAILED_TO_LOAD_DELEGATE,

--- a/src/pages/proposals/forms/new-proposal-form.tsx
+++ b/src/pages/proposals/forms/new-proposal-form.tsx
@@ -6,7 +6,7 @@ import Input from '../../../components/input';
 import Textarea from '../../../components/textarea';
 import { Tooltip } from '../../../components/tooltip';
 import { ModalFooter, ModalHeader } from '../../../components/modal';
-import { goEncodeEvmScript, NewProposalFormData } from '../../../logic/proposals/encoding';
+import { goEncodeEvmScript, EncodedEvmScriptError, NewProposalFormData } from '../../../logic/proposals/encoding';
 import { Api3Agent } from '../../../contracts';
 import { filterAlphanumerical, images } from '../../../utils';
 import styles from './new-proposal-form.module.scss';
@@ -77,8 +77,13 @@ const NewProposalForm = (props: Props) => {
 
     const goRes = await goEncodeEvmScript(provider, formData, api3Agent);
     if (!goRes.success) {
-      const { field, value } = goRes.error;
-      newErrors[field] = value;
+      if (goRes.error instanceof EncodedEvmScriptError) {
+        const { field, value } = goRes.error;
+        newErrors[field] = value;
+      } else {
+        // We should always get an EncodedEvmScriptError, but we give the user a message just in case it is not
+        newErrors.generic = 'Failed to encode';
+      }
       foundErrors = true;
     }
 

--- a/src/utils/error-handling.ts
+++ b/src/utils/error-handling.ts
@@ -9,7 +9,7 @@ type ErrorWithCode = Error & { code?: number };
 export const isUserRejection = (err: ErrorWithCode) => err.code === 4001 || err.code === 4100;
 
 export const handleTransactionError = async <T>(transaction: Promise<T>) => {
-  const goTransaction = await go(transaction);
+  const goTransaction = await go(() => transaction);
 
   if (!goTransaction.success) {
     if (isUserRejection(goTransaction.error)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,12 +15,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@api3/promise-utils@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@api3/promise-utils/-/promise-utils-0.1.0.tgz#bc0678a5d19b32274192656dc787a131e22d82dc"
-  integrity sha512-hel2yq9p9d5Yki9nf+9S7XNDzko+FVzYUps5JGwl6XvV5eBaEUDkEeTG5ulyUORzJdplfT+KyE1zxwIMG/ZfhQ==
-  dependencies:
-    "@lifeomic/attempt" "^3.0.2"
+"@api3/promise-utils@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@api3/promise-utils/-/promise-utils-0.3.0.tgz#e7ebf92bfd8c1d39983321fc5445070c51fce176"
+  integrity sha512-fH3CzEcsCQjoX6BZ5M+3yRIXZ2zz4/nFdzKUB4wvn3KjvvzvroHFZrzhbKa4mB9E4AS0xnou1AXhlrnN5Fcy+A==
 
 "@apideck/better-ajv-errors@^0.3.1":
   version "0.3.6"
@@ -1930,11 +1928,6 @@
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
-
-"@lifeomic/attempt@^3.0.2":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.3.tgz#e742a5b85eb673e2f1746b0f39cb932cbc6145bb"
-  integrity sha512-GlM2AbzrErd/TmLL3E8hAHmb5Q7VhDJp35vIbyPVA5Rz55LZuRr8pwL3qrwwkVNo05gMX1J44gURKb4MHQZo7w==
 
 "@lit-labs/ssr-dom-shim@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@api3/promise-utils@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@api3/promise-utils/-/promise-utils-0.3.0.tgz#e7ebf92bfd8c1d39983321fc5445070c51fce176"
-  integrity sha512-fH3CzEcsCQjoX6BZ5M+3yRIXZ2zz4/nFdzKUB4wvn3KjvvzvroHFZrzhbKa4mB9E4AS0xnou1AXhlrnN5Fcy+A==
+"@api3/promise-utils@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@api3/promise-utils/-/promise-utils-0.4.0.tgz#d1dcd77d74377b4fdb3071d2cc76d98c9151309c"
+  integrity sha512-+8fcNjjQeQAuuSXFwu8PMZcYzjwjDiGYcMUfAQ0lpREb1zHonwWZ2N0B9h/g1cvWzg9YhElbeb/SyhCrNm+b/A==
 
 "@apideck/better-ajv-errors@^0.3.1":
   version "0.3.6"


### PR DESCRIPTION
Resolves #395 

### What does this change?
- updates `go()` usages to pass a function that returns a promise (instead of just the promise)
- fixes the type errors in the `goEncodeEvmScript()` function when calling the `fail()` function:
```
Type 'GoResultError<Error>' is not assignable to type 'GoResultError<EncodedEvmScriptError>'.
```
- increases the Cypress default command timeout from 10s to 15s (had 3 test failures in a row due to the timeout being hit)

### How did you action this task?
W.r.t. the type errors in the `goEncodeEvmScript()`, instead of passing the `EncodedEvmScriptError` type argument to the `fail()` function for each call, I let the type be the broader `Error`, and used `instanceof` when using the error when validating the proposal form:

```diff
    if (!goRes.success) {
+     if (goRes.error instanceof EncodedEvmScriptError) {
        const { field, value } = goRes.error;
        newErrors[field] = value;
+     } else {
+       // We should always get an EncodedEvmScriptError, but we give the user a message just in case it is not
+       newErrors.generic = 'Failed to encode';
+     }
      foundErrors = true;
    }
```