### PR TITLE
Upgrade wagmi to v1 (part 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
   "browserslist": {
     "production": [
       ">0.2%",
+      "not ie <= 99",
+      "not android <= 4.4.4",
       "not dead",
       "not op_mini all"
     ],

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -289,13 +289,7 @@ function WarningIcon(props: ComponentProps<'svg'>) {
 
 function EnsName(props: { address: Address }) {
   const { address } = props;
-  const { data } = useEnsName({
-    address,
-    onError(error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-    },
-  });
+  const { data } = useEnsName({ address });
 
   return <>{data || address}</>;
 }

--- a/src/pages/proposal-commons/proposal-details/proposal-details.tsx
+++ b/src/pages/proposal-commons/proposal-details/proposal-details.tsx
@@ -289,7 +289,13 @@ function WarningIcon(props: ComponentProps<'svg'>) {
 
 function EnsName(props: { address: Address }) {
   const { address } = props;
-  const { data } = useEnsName({ address });
+  const { data } = useEnsName({
+    address,
+    onError(error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    },
+  });
 
   return <>{data || address}</>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7551,7 +7551,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
-fork-ts-checker-webpack-plugin@^6.5.0, fork-ts-checker-webpack-plugin@^6.5.3:
+fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz#eda2eff6e22476a2688d10661688c47f611b37f3"
   integrity sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==


### PR DESCRIPTION
Follow up to https://github.com/api3dao/api3-dao-dashboard/pull/424

### What does this change?
- updates the browserlist to filter out ancient browsers (IE and Android browser version <= 4.4.4) so that transpilation doesn't interfere with BigInts. The issue is described [here](https://github.com/hirosystems/stacks.js/issues/1096#issuecomment-946350299)