### PR TITLE
Bump versions of Actions steps in order to add provenance

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker Metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: api3/dao-dashboard
           tags: |
@@ -26,12 +26,12 @@ jobs:
             type=sha,prefix=,suffix=,format=long
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/production' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ github.ref == 'refs/heads/production' }}


### PR DESCRIPTION
"Attestations are supported with version 4 and later of the docker/build-push-action" ([source](https://docs.docker.com/build/ci/github-actions/attestations/)) - this PR updates from v3 to v5, and updates other steps as well.

EDIT: The `production` branch is the only one from which images get pushed because of this bool:

https://github.com/api3dao/api3-dao-dashboard/blob/b8befd30d13bf352c12b2bfd4e0a0b239352c5de/.github/workflows/build-docker.yml#L37

so I originally opened the PR against `production`, but realized that didn't make sense since commits are merged from `main` to `production`. In rebasing, I did notice GitHub is having some trouble reconciling `main` and `production`: see [this compare](https://github.com/api3dao/api3-dao-dashboard/compare/production...main). I'm guessing, based on the [co-authored commits on production](https://github.com/api3dao/api3-dao-dashboard/commits/production/) that a "rebase and merge" was used in #432 instead of using a merge commit. 