### PR TITLE
Provide REACT_APP_MAINNET_PROVIDER_URL env variable when building Docker image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,5 +34,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          build-args: |
+            REACT_APP_MAINNET_PROVIDER_URL=${{ secrets.REACT_APP_MAINNET_PROVIDER_URL }}
           push: ${{ github.ref == 'refs/heads/production' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # This Dockerfile builds a mainnet version for API3 DAO dashboard
 
 FROM node:16-alpine as builder
+ARG REACT_APP_MAINNET_PROVIDER_URL
+# The mainnet provider URL is required at build time
+ENV REACT_APP_MAINNET_PROVIDER_URL=$REACT_APP_MAINNET_PROVIDER_URL
 # The Wallet Connect project ID is required at build time, and it is OK to hardcode because the project ID
 # is discoverable when using the dApp.
 ENV REACT_APP_PROJECT_ID=0b2e430162b0e6c93619b3d65cf90d4e

--- a/README.md
+++ b/README.md
@@ -31,13 +31,16 @@ docker run --rm --publish 7770:80 --name api3-dao-dashboard api3/dao-dashboard:l
 
 ### Building from source
 
-Alternatively, you can build the Docker image from source. Note that the production code is located on the `production`
-branch.
+Alternatively, you can build the Docker image from source. Note that:
+
+- the production code is located on the `production` branch
+- you need to provide your mainnet provider URL as a build arg (`REACT_APP_MAINNET_PROVIDER_URL`) when building the
+  image
 
 ```sh
 git clone --depth=1 --branch production https://github.com/api3dao/api3-dao-dashboard.git
 cd api3-dao-dashboard
-docker build --tag api3-dao-dashboard .
+docker build --build-arg="REACT_APP_MAINNET_PROVIDER_URL=..." --tag api3-dao-dashboard .
 docker run --rm --publish 7770:80 --name api3-dao-dashboard api3-dao-dashboard
 ```
 


### PR DESCRIPTION
Closes #439 

### What does this change?
- builds the Docker image with the `REACT_APP_MAINNET_PROVIDER_URL` env variable through the use of a build arg
- updates documentation