### PR TITLE
Bump fleek/create-react-app to node-18 for local verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ services:
       - '4873:4873'
 
   app:
-    image: fleek/create-react-app
+    image: fleek/create-react-app:node-18
     command: sh -c 'npm set registry http://verdaccio:4873 && yarn && yarn build'
     working_dir: /workspace/build
     environment:


### PR DESCRIPTION
When attempting to verify the fleek build locally using the following command:

https://github.com/api3dao/api3-dao-dashboard/blob/ef58bfb106d4419c5fbc9828ec4a335831dce883/README.md?plain=1#L78 

with the suggested `docker-compose.yml` file:

https://github.com/api3dao/api3-dao-dashboard/blob/ef58bfb106d4419c5fbc9828ec4a335831dce883/README.md?plain=1#L56-L76

I received the following package incompatibility build error originating from the use of the `fleek/create-react-app` image (which is 3 years old and uses Node.js 16) 

```
❯ docker-compose run --rm app
WARN[0000] /home/derek/api3/api3-dao-dashboard/docker-compose.yml: `version` is obsolete
[+] Creating 1/0
 ✔ Network api3-dao-dashboard_default  Created                                                                                  0.0s
[+] Running 10/10
 ✔ app Pulled                                                                                                                  32.9s
   ✔ 0bc3020d05f1 Pull complete                                                                                                13.9s
   ✔ a110e5871660 Pull complete                                                                                                 1.5s
   ✔ 83d3c0fa203a Pull complete                                                                                                 2.3s
   ✔ a8fd09c11b02 Pull complete                                                                                                 7.7s
   ✔ 14feb89c4a52 Pull complete                                                                                                23.7s
   ✔ 612a5de913f3 Pull complete                                                                                                 8.1s
   ✔ 06077b7d0fc4 Pull complete                                                                                                14.3s
   ✔ 2fd6f92aa390 Pull complete                                                                                                14.6s
   ✔ 43a1e86f1929 Pull complete                                                                                                14.7s
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
error ts-api-utils@1.0.3: The engine "node" is incompatible with this module. Expected version ">=16.13.0". Got "16.4.2" 
```

Updating to use `fleek/create-react-app:node-18` resulted in the build and local verification succeeding.