### PR TITLE
Add cookie consent logic

### DIFF
--- a/cypress/e2e/footer.cy.ts
+++ b/cypress/e2e/footer.cy.ts
@@ -3,19 +3,34 @@ import { HOME_PAGE } from '../support/common';
 it('renders footer and error reporting', () => {
   cy.visit(HOME_PAGE).dataCy('error-reporting').should('exist');
 
-  // Disallow error reporting
-  cy.dataCy('error-reporting').find('input').click();
-  cy.findByText('Done').click();
+  // Enable error report and analytics
+  cy.dataCy('error-reporting')
+    .findByRole('button', { name: /accept all/i })
+    .click();
   cy.dataCy('error-reporting')
     .should('not.exist')
-    .should(() => {
-      expect(localStorage.getItem('reportErrors')).to.equal('false');
+    .then(() => {
+      expect(localStorage.getItem('allow-error-reporting')).to.equal('true');
+      expect(localStorage.getItem('allow-analytics')).to.equal('true');
     });
 
-  // On subsequent page visit there is no notice
-  cy.reload().should(() => {
-    expect(localStorage.getItem('reportErrors')).to.equal('false');
+  // On subsequent page visit the error reporting notice should not be shown
+  cy.reload().then(() => {
+    expect(cy.dataCy('error-reporting').should('not.exist'));
   });
+
+  // Open the privacy settings modal from the footer and disable error reporting and analytics
+  cy.findByRole('button', { name: /error reporting/i }).click();
+  cy.findByRole('button', { name: /manage settings/i }).click();
+  cy.findByRole('checkbox', { name: /allow error reporting/i }).click();
+  cy.findByRole('checkbox', { name: /allow analytics cookies/i }).click();
+  cy.findByRole('button', { name: /save settings/i }).click();
+  cy.dataCy('error-reporting')
+    .should('not.exist')
+    .then(() => {
+      expect(localStorage.getItem('allow-error-reporting')).to.equal('false');
+      expect(localStorage.getItem('allow-analytics')).to.equal('false');
+    });
 
   // Footer links should open the pages they link to in a new tab
   cy.findByText('Github').should('have.attr', 'target', '_blank');

--- a/cypress/support/common.ts
+++ b/cypress/support/common.ts
@@ -33,8 +33,10 @@ export const abbrStr = (str: string) => {
 export const EPOCH_LENGTH = 7 * 60 * 60 * 24; // in seconds
 
 export const closeErrorReportingNotice = () => {
-  cy.dataCy('error-reporting').findByText('Done').click();
-  cy.findByText('Done').should('not.exist');
+  cy.dataCy('error-reporting')
+    .findByRole('button', { name: /accept all/i })
+    .click();
+  cy.dataCy('error-reporting').should('not.exist');
 };
 
 export const HOME_PAGE = 'http://localhost:3000/#/';

--- a/src/components/checkbox/checkbox.module.scss
+++ b/src/components/checkbox/checkbox.module.scss
@@ -1,0 +1,123 @@
+@import '../../styles/variables.module.scss';
+@import '../../styles/fonts.module.scss';
+
+.checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+
+  &,
+  * {
+    cursor: pointer;
+    transition: all 0.1s;
+  }
+
+  .checkmark {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 16px;
+    min-width: 16px;
+    height: 16px;
+    width: 16px;
+    background-color: $color-gray-50;
+    border: 1px solid $color-dark-blue-50;
+    border-radius: 2px;
+    margin-top: 2px;
+
+    svg {
+      margin: auto;
+      width: 12px;
+      height: 12px;
+      color: $color-gray-50;
+    }
+  }
+
+  .checkboxTextBlock {
+    display: flex;
+    flex-direction: column;
+    @include font-body-12;
+
+    label {
+      color: $color-dark-blue-800;
+    }
+
+    .description {
+      color: $color-gray-500;
+    }
+  }
+
+  &[aria-checked='true'] {
+    .checkmark {
+      background-color: $color-dark-blue-400;
+      border-color: $color-gray-50;
+    }
+  }
+
+  &:hover:not([aria-disabled='true']) {
+    .checkmark {
+      background-color: $color-base-light;
+      border-color: $color-dark-blue-400;
+
+      svg {
+        color: $color-dark-blue-400;
+      }
+    }
+
+    .checkboxTextBlock {
+      label {
+        color: $color-gray-900;
+      }
+
+      .description {
+        color: $color-gray-600;
+      }
+    }
+  }
+
+  &[aria-disabled='true'] {
+    pointer-events: none;
+
+    .checkmark {
+      background-color: transparent;
+      border-color: $color-gray-200;
+
+      svg {
+        color: $color-gray-200;
+      }
+    }
+
+    .checkboxTextBlock {
+      label {
+        color: $color-gray-400;
+      }
+
+      .description {
+        color: $color-gray-200;
+      }
+    }
+  }
+}
+
+@media (min-width: $sm) {
+  .checkbox {
+    gap: 12px;
+
+    .checkmark {
+      min-height: 20px;
+      min-width: 20px;
+      height: 20px;
+      width: 20px;
+      margin-top: 2px;
+
+      svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    .checkboxTextBlock {
+      @include font-body-9;
+    }
+  }
+}

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,0 +1,44 @@
+import { KeyboardEvent, ReactNode } from 'react';
+import { CheckIcon } from '../icons';
+import styles from './checkbox.module.scss';
+
+interface Props {
+  label?: string;
+  checked: boolean;
+  children?: ReactNode;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+const CheckBox = ({ label, checked, children, disabled, onChange }: Props) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onChange(!checked);
+    }
+  };
+
+  return (
+    <div
+      id={label}
+      className={styles.checkbox}
+      tabIndex={0}
+      role="checkbox"
+      aria-checked={checked}
+      aria-disabled={disabled}
+      onClick={() => {
+        onChange(!checked);
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      <span className={styles.checkmark}>{checked && <CheckIcon />}</span>
+
+      <div className={styles.checkboxTextBlock}>
+        <label htmlFor={label}>{label}</label>
+        {children && <div className={styles.description}>{children}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default CheckBox;

--- a/src/components/checkbox/index.ts
+++ b/src/components/checkbox/index.ts
@@ -1,0 +1,2 @@
+export { default } from './checkbox';
+export * from './checkbox';

--- a/src/components/external-link/external-link.tsx
+++ b/src/components/external-link/external-link.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react';
+import { KeyboardEvent, MouseEvent, ReactNode, useEffect } from 'react';
 
 interface Props {
   className?: string;
@@ -22,8 +22,19 @@ const ExternalLink = (props: Props) => {
     }
   }, [href, props.href]);
 
+  const handleEvent = (event: KeyboardEvent<HTMLAnchorElement> | MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation();
+  };
+
   return (
-    <a href={href} className={className} target="_blank" rel="noopener noreferrer">
+    <a
+      href={href}
+      className={className}
+      target="_blank"
+      rel="noopener noreferrer"
+      onKeyDown={handleEvent}
+      onClick={handleEvent}
+    >
       {children}
     </a>
   );

--- a/src/components/external-link/external-link.tsx
+++ b/src/components/external-link/external-link.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent, MouseEvent, ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 interface Props {
   className?: string;
@@ -22,19 +22,8 @@ const ExternalLink = (props: Props) => {
     }
   }, [href, props.href]);
 
-  const handleEvent = (event: KeyboardEvent<HTMLAnchorElement> | MouseEvent<HTMLAnchorElement>) => {
-    event.stopPropagation();
-  };
-
   return (
-    <a
-      href={href}
-      className={className}
-      target="_blank"
-      rel="noopener noreferrer"
-      onKeyDown={handleEvent}
-      onClick={handleEvent}
-    >
+    <a href={href} className={className} target="_blank" rel="noopener noreferrer">
       {children}
     </a>
   );

--- a/src/components/external-link/external-link.tsx
+++ b/src/components/external-link/external-link.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef, useEffect } from 'react';
 
-interface Props extends ComponentPropsWithoutRef<'a'> {
+interface Props extends Omit<ComponentPropsWithoutRef<'a'>, 'target' | 'rel'> {
   href: string;
 }
 

--- a/src/components/external-link/external-link.tsx
+++ b/src/components/external-link/external-link.tsx
@@ -1,32 +1,37 @@
-import { ReactNode, useEffect } from 'react';
+import { ComponentPropsWithoutRef, useEffect } from 'react';
 
-interface Props {
-  className?: string;
+interface Props extends ComponentPropsWithoutRef<'a'> {
   href: string;
-  children: ReactNode;
 }
 
 const ExternalLink = (props: Props) => {
-  const { className, children } = props;
+  const { children, href: incomingHref, ...rest } = props;
 
-  let href = props.href.trim();
-  const urlRegex = /^https?:\/\//i; // Starts with https:// or http:// (case insensitive)
-  if (!urlRegex.test(href)) {
-    href = 'about:blank';
-  }
+  const href = cleanHref(incomingHref);
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'development' && href === 'about:blank') {
       // eslint-disable-next-line no-console
-      console.warn(`An invalid URL has been provided: "${props.href}". Only https:// or http:// URLs are allowed.`);
+      console.warn(`An invalid URL has been provided: "${incomingHref}". Only https:// or http:// URLs are allowed.`);
     }
-  }, [href, props.href]);
+  }, [href, incomingHref]);
 
   return (
-    <a href={href} className={className} target="_blank" rel="noopener noreferrer">
+    <a target="_blank" rel="noopener noreferrer" href={href} {...rest}>
       {children}
     </a>
   );
+};
+
+const cleanHref = (href: string) => {
+  const urlRegex = /^https?:\/\//i; // Starts with https:// or http:// (case insensitive)
+  const trimmedHref = href.trim();
+
+  if (!urlRegex.test(trimmedHref)) {
+    return 'about:blank';
+  }
+
+  return trimmedHref;
 };
 
 export default ExternalLink;

--- a/src/components/icons/check.tsx
+++ b/src/components/icons/check.tsx
@@ -1,0 +1,15 @@
+import { ComponentProps } from 'react';
+
+export const CheckIcon = (props: ComponentProps<'svg'>) => {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M13 4.25L6.125 11.125L3 8"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,8 +1,9 @@
-import { CheckCircleFillIcon } from './check-circle-fill';
 import { CheckboxRadioIcon } from './checkbox-radio';
+import { CheckCircleFillIcon } from './check-circle-fill';
+import { CheckIcon } from './check';
 import { CloseIcon } from './close';
 import { CrossIcon } from './cross';
 import { HelpOutlineIcon } from './help-outline';
 import { InfoCircleIcon } from './info-circle';
 
-export { CheckCircleFillIcon, CheckboxRadioIcon, CloseIcon, CrossIcon, HelpOutlineIcon, InfoCircleIcon };
+export { CheckCircleFillIcon, CheckboxRadioIcon, CheckIcon, CloseIcon, CrossIcon, HelpOutlineIcon, InfoCircleIcon };

--- a/src/components/layout/error-reporting-notice/error-reporting-notice.module.scss
+++ b/src/components/layout/error-reporting-notice/error-reporting-notice.module.scss
@@ -10,13 +10,8 @@
   position: fixed;
   width: 100%;
   bottom: 0;
-  height: 221px;
   background: $color-dark-blue-700;
   align-items: center;
-
-  @media (min-width: $md) {
-    height: 92px;
-  }
 
   &::before {
     content: '';
@@ -29,25 +24,12 @@
   }
 }
 
-.closeButton {
-  z-index: 1;
-  height: 24px;
-  align-self: flex-end;
-  margin: 20px 24px;
-  position: absolute;
-  color: $color-base-light;
-  cursor: pointer;
-
-  &:hover {
-    color: $color-blue-25;
-  }
-}
-
 .content {
   padding: 64px 24px 32px 24px;
   display: flex;
   align-items: center;
   justify-content: space-around;
+  gap: 24px;
   flex: 1;
   flex-direction: column;
   @include font-body-15;
@@ -62,51 +44,8 @@
   }
 }
 
-.buttons {
-  display: flex;
-}
-
-.checkboxWrapper {
-  min-width: 160px; // Make sure the checkbox and its label are on a single line
-  display: flex;
-  align-items: center;
-
-  label {
-    cursor: pointer;
-  }
-
-  input {
-    $size: 16px;
-
-    width: $size;
-    height: $size;
-    margin-right: $space-xs;
-    appearance: none;
-    border: none;
-    border-radius: 4px;
-    outline: none;
-    transition-duration: 0.3s;
-    background-color: $secondary-black-color;
-    cursor: pointer;
-  }
-
-  input:checked {
-    background-color: $green-color;
-  }
-
-  input:checked::before {
-    content: '\2713';
-    text-align: center;
-    color: $secondary-black-color;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100%;
-  }
-
-  input:active {
-    border: 2px solid $secondary-black-color;
-  }
+.externalLinkIcon {
+  margin-left: 4px;
 }
 
 .notice {
@@ -118,6 +57,46 @@
   }
 }
 
-.externalLinkIcon {
-  margin-left: 4px;
+.buttons {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+
+  .manageSettingsButton {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  @media (min-width: $md) {
+    width: auto;
+    gap: 32px;
+  }
+}
+
+.closeButton {
+  z-index: 1;
+  align-self: flex-end;
+  margin: 20px 24px;
+  position: absolute;
+  color: $color-base-light;
+  cursor: pointer;
+  padding: 0;
+  border: none;
+  background: none;
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+
+  &:hover {
+    color: $color-blue-25;
+  }
+
+  @media (min-width: $md) {
+    svg {
+      width: 28px;
+      height: 28px;
+    }
+  }
 }

--- a/src/components/layout/error-reporting-notice/error-reporting-notice.tsx
+++ b/src/components/layout/error-reporting-notice/error-reporting-notice.tsx
@@ -46,8 +46,8 @@ const ErrorReportingNotice = (props: WelcomeModalContentProps) => {
             <ExternalLink className={styles.dark} href={links.SENTRY}>
               Sentry
             </ExternalLink>
-            <img src={images.externalLink} alt="" className={styles.externalLinkIcon} />. We do not gather IP address or
-            user agent information.
+            <img src={images.externalLink} alt="" className={styles.externalLinkIcon} /> and use analytics cookies to
+            improve our products.
           </div>
           <div className={styles.buttons}>
             <Button

--- a/src/components/layout/error-reporting-notice/error-reporting-notice.tsx
+++ b/src/components/layout/error-reporting-notice/error-reporting-notice.tsx
@@ -7,6 +7,7 @@ import { links } from '../../../utils/links';
 import { ALLOW_ANALYTICS, ALLOW_ERROR_REPORTING, initAnalytics } from '../../../utils/analytics';
 import PrivacySettingsModal from '../privacy-settings-modal';
 import { CrossIcon } from '../../icons';
+import { initSentry } from '../../../utils/error-reporting';
 
 interface WelcomeModalContentProps {
   onShowNotice: (showNotice: boolean) => void;
@@ -27,7 +28,7 @@ const ErrorReportingNotice = (props: WelcomeModalContentProps) => {
     }
 
     if (allowReporting) {
-      // initSentry(); // TBD later
+      initSentry();
     }
 
     onShowNotice(false);

--- a/src/components/layout/error-reporting-notice/error-reporting-notice.tsx
+++ b/src/components/layout/error-reporting-notice/error-reporting-notice.tsx
@@ -1,66 +1,73 @@
-import { useRef, useState } from 'react';
-import { ERROR_REPORTING_CONSENT_KEY_NAME, images, isErrorReportingAllowed } from '../../../utils';
+import { useState } from 'react';
+import { images } from '../../../utils';
 import Button from '../../button';
-import { triggerOnEnter } from '../../modal';
 import styles from './error-reporting-notice.module.scss';
 import ExternalLink from '../../external-link';
+import { links } from '../../../utils/links';
+import { ALLOW_ANALYTICS, ALLOW_ERROR_REPORTING, initAnalytics } from '../../../utils/analytics';
+import PrivacySettingsModal from '../privacy-settings-modal';
+import { CrossIcon } from '../../icons';
 
 interface WelcomeModalContentProps {
-  onClose: () => void;
+  onShowNotice: (showNotice: boolean) => void;
 }
 
 const ErrorReportingNotice = (props: WelcomeModalContentProps) => {
-  const { onClose } = props;
-  const defaultReportingValue = localStorage.getItem(ERROR_REPORTING_CONSENT_KEY_NAME);
-  const [errorReportingEnabled, setErrorReportingEnabled] = useState(
-    defaultReportingValue === null || isErrorReportingAllowed(defaultReportingValue)
-  );
-  const onErrorReportingNoticeConfirm = () => {
-    localStorage.setItem(ERROR_REPORTING_CONSENT_KEY_NAME, errorReportingEnabled.toString());
-    onClose();
+  const { onShowNotice } = props;
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleSubmit = (allowAnalytics: boolean, allowReporting: boolean) => {
+    localStorage.setItem(ALLOW_ERROR_REPORTING, allowReporting.toString());
+    localStorage.setItem(ALLOW_ANALYTICS, allowAnalytics.toString());
+
+    if (allowAnalytics) {
+      initAnalytics();
+      (window as any).clarity?.('consent');
+    }
+
+    if (allowReporting) {
+      // initSentry(); // TBD later
+    }
+
+    onShowNotice(false);
+    setIsModalOpen(false);
   };
-  const errorReportingRef = useRef<HTMLInputElement>(null);
-  const toggleCheckbox = () => setErrorReportingEnabled((checked) => !checked);
 
   return (
-    // NOTE: Not using focus lock, because that would prevent user from signing in
     <>
-      <div data-cy="error-reporting" className={styles.wrapper} ref={errorReportingRef}>
+      <PrivacySettingsModal open={isModalOpen} onCancel={() => setIsModalOpen(false)} onSubmit={handleSubmit} />
+
+      <div data-cy="error-reporting" className={styles.wrapper}>
         <div className={styles.content}>
           <div className={styles.notice}>
             In order to provide the best services for you, we collect anonymized error data through{' '}
-            <ExternalLink className={styles.dark} href="https://sentry.io/">
+            <ExternalLink className={styles.dark} href={links.SENTRY}>
               Sentry
             </ExternalLink>
             <img src={images.externalLink} alt="" className={styles.externalLinkIcon} />. We do not gather IP address or
             user agent information.
           </div>
           <div className={styles.buttons}>
-            <div className={styles.checkboxWrapper} tabIndex={0} onKeyPress={triggerOnEnter(toggleCheckbox)}>
-              <input
-                type="checkbox"
-                id="errorReporting"
-                name="errorReporting"
-                checked={errorReportingEnabled}
-                onChange={toggleCheckbox}
-                tabIndex={-1}
-              />
-              <label htmlFor="errorReporting">Allow error reporting</label>
-            </div>
-            <Button type="primary" theme="dark" onClick={onErrorReportingNoticeConfirm}>
-              Done
+            <Button
+              className={styles.manageSettingsButton}
+              type="text-blue"
+              size="sm"
+              theme="dark"
+              onClick={() => setIsModalOpen(true)}
+            >
+              Manage Settings
+            </Button>
+            <Button type="primary" size="sm" theme="dark" onClick={() => handleSubmit(true, true)}>
+              Accept All
             </Button>
           </div>
         </div>
-        <img
-          className={styles.closeButton}
-          onClick={onErrorReportingNoticeConfirm}
-          src={images.close}
-          alt="confirm and close icon"
-          tabIndex={0}
-          // This is not a regular "modal" and shouldn't be closed with ESC
-          onKeyPress={triggerOnEnter(onErrorReportingNoticeConfirm)}
-        />
+
+        <button className={styles.closeButton} onClick={() => onShowNotice(false)}>
+          <CrossIcon />
+          <span className="sr-only">Close</span>
+        </button>
       </div>
     </>
   );

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -2,12 +2,12 @@ import { ReactNode, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Navigation from '../navigation';
 import Header from '../header';
-import { ERROR_REPORTING_CONSENT_KEY_NAME } from '../../utils';
 import styles from './layout.module.scss';
 import Button from '../button';
 import ErrorReportingNotice from './error-reporting-notice';
 import { DesktopMenu } from '../menu';
 import ExternalLink from '../external-link';
+import { ALLOW_ANALYTICS, ALLOW_ERROR_REPORTING } from '../../utils/analytics';
 
 type Props = {
   children: ReactNode;
@@ -30,13 +30,13 @@ interface BaseLayoutProps {
 }
 
 export const BaseLayout = ({ children, subtitle }: BaseLayoutProps) => {
-  const [errorReportingNoticeOpen, setErrorReportingNoticeOpen] = useState(
-    localStorage.getItem(ERROR_REPORTING_CONSENT_KEY_NAME) === null
+  const [showNotice, setShowNotice] = useState(
+    () => localStorage.getItem(ALLOW_ERROR_REPORTING) === null || localStorage.getItem(ALLOW_ANALYTICS) === null
   );
 
   const footerLinks = [
     { text: 'About API3', href: 'https://api3.org/' },
-    { text: 'Error Reporting', onClick: () => setErrorReportingNoticeOpen(true) },
+    { text: 'Error Reporting', onClick: () => setShowNotice(true) },
     { text: 'Github', href: 'https://github.com/api3dao/api3-dao-dashboard' },
   ];
 
@@ -53,8 +53,8 @@ export const BaseLayout = ({ children, subtitle }: BaseLayoutProps) => {
           <main className={styles.main}>{children}</main>
         </div>
         <footer className={styles.footer}>
-          {errorReportingNoticeOpen ? (
-            <ErrorReportingNotice onClose={() => setErrorReportingNoticeOpen(false)} />
+          {showNotice ? (
+            <ErrorReportingNotice onShowNotice={setShowNotice} />
           ) : (
             <div className={styles.footerContent}>
               {footerLinks.map((link) =>

--- a/src/components/layout/privacy-settings-modal/index.ts
+++ b/src/components/layout/privacy-settings-modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './privacy-settings-modal';

--- a/src/components/layout/privacy-settings-modal/privacy-settings-modal.module.scss
+++ b/src/components/layout/privacy-settings-modal/privacy-settings-modal.module.scss
@@ -1,0 +1,80 @@
+@import '../../../styles/variables.module.scss';
+@import '../../../styles/fonts.module.scss';
+@import '../../button/variants/link-blue.module.scss';
+
+.privacySettingsModalContent {
+  display: flex;
+  flex-direction: column;
+
+  .privacyDescription {
+    margin-bottom: 40px;
+
+    > span {
+      @include font-body-9;
+      color: $color-dark-blue-400;
+      margin: 0;
+    }
+
+    .privacyPolicyButton {
+      @include link-blue;
+      white-space: nowrap;
+      text-decoration: none;
+    }
+
+    .externalLinkIcon {
+      margin-left: 0.5ch;
+    }
+  }
+
+  .checkboxes {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+
+    .checkboxContainer {
+      .checkboxTextBlock {
+        gap: 8px;
+      }
+
+      .sentryButton {
+        display: inline-block;
+        margin-right: 0.5ch;
+
+        a {
+          @include link-blue;
+          @include font-link-3;
+          white-space: nowrap;
+          text-decoration: none;
+        }
+      }
+    }
+  }
+
+  @media (min-width: $sm) {
+    .privacyDescription {
+      margin-bottom: 40px;
+
+      > span {
+        @include font-body-6;
+      }
+    }
+
+    .checkboxes {
+      .checkboxContainer {
+        .sentryButton {
+          a {
+            @include font-link-2;
+          }
+        }
+      }
+    }
+  }
+}
+
+.saveSettingsButton {
+  width: 100%;
+
+  @media (min-width: $sm) {
+    width: auto;
+  }
+}

--- a/src/components/layout/privacy-settings-modal/privacy-settings-modal.tsx
+++ b/src/components/layout/privacy-settings-modal/privacy-settings-modal.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { ALLOW_ANALYTICS, ALLOW_ERROR_REPORTING } from '../../../utils/analytics';
+import { Modal, ModalFooter, ModalHeader } from '../../modal';
+import styles from './privacy-settings-modal.module.scss';
+import Button from '../../button';
+import CheckBox from '../../checkbox';
+import { links } from '../../../utils/links';
+import classNames from 'classnames';
+import ExternalLink from '../../external-link';
+import { images } from '../../../utils';
+
+interface Props {
+  open: boolean;
+  onCancel: () => void;
+  onSubmit: (allowAnalytics: boolean, allowReporting: boolean) => void;
+}
+
+const PrivacySettingsModal = (props: Props) => {
+  const { open, onCancel, onSubmit } = props;
+
+  const storedErrorReportingFlag = localStorage.getItem(ALLOW_ERROR_REPORTING);
+  const storedAnalyticsFlag = localStorage.getItem(ALLOW_ANALYTICS);
+
+  const [allowReporting, setAllowReporting] = useState(() => storedErrorReportingFlag === 'true');
+  const [allowAnalytics, setAllowAnalytics] = useState(() => storedAnalyticsFlag === 'true');
+
+  return (
+    <Modal open={open} onClose={onCancel}>
+      <ModalHeader>Privacy Settings</ModalHeader>
+
+      <div className={styles.privacySettingsModalContent}>
+        <div className={styles.privacyDescription}>
+          <span>
+            In order to provide the best services for you, we collect anonymized error data through Sentry and use
+            analytics cookies to improve our products. We do not gather IP address or user agent information.{' '}
+          </span>
+          <ExternalLink className={styles.privacyPolicyButton} href={links.PRIVACY_POLICY}>
+            Visit our Privacy Policy
+          </ExternalLink>
+          <img src={images.externalLink} alt="" className={styles.externalLinkIcon} />
+        </div>
+
+        <div className={styles.checkboxes}>
+          <div className={classNames(styles.checkboxContainer, { selected: allowReporting })}>
+            <CheckBox checked={allowReporting} onChange={setAllowReporting} label="Allow error reporting">
+              <div className={styles.sentryButton}>
+                <ExternalLink href={links.SENTRY}>Sentry</ExternalLink>{' '}
+                <img src={images.externalLink} alt="" className={styles.externalLinkIcon} />
+              </div>
+              collects error data to improve the performance and reliability of our services, and helps us identify and
+              fix issues quickly, ensuring a smoother experience for you.
+            </CheckBox>
+          </div>
+
+          <div className={classNames(styles.checkboxContainer, { selected: allowAnalytics })}>
+            <CheckBox checked={allowAnalytics} onChange={setAllowAnalytics} label="Allow analytics cookies">
+              Analytics cookies help us to improve our website by collecting and reporting information on how you use
+              it.
+            </CheckBox>
+          </div>
+        </div>
+      </div>
+
+      <ModalFooter>
+        <Button
+          className={styles.saveSettingsButton}
+          type="primary"
+          sm={{ size: 'lg' }}
+          onClick={() => onSubmit(allowAnalytics, allowReporting)}
+        >
+          Save Settings
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default PrivacySettingsModal;

--- a/src/components/layout/privacy-settings-modal/privacy-settings-modal.tsx
+++ b/src/components/layout/privacy-settings-modal/privacy-settings-modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { KeyboardEvent, MouseEvent, useState } from 'react';
 import { ALLOW_ANALYTICS, ALLOW_ERROR_REPORTING } from '../../../utils/analytics';
 import { Modal, ModalFooter, ModalHeader } from '../../modal';
 import styles from './privacy-settings-modal.module.scss';
@@ -24,6 +24,10 @@ const PrivacySettingsModal = (props: Props) => {
   const [allowReporting, setAllowReporting] = useState(() => storedErrorReportingFlag === 'true');
   const [allowAnalytics, setAllowAnalytics] = useState(() => storedAnalyticsFlag === 'true');
 
+  const handleEvent = (event: KeyboardEvent<HTMLAnchorElement> | MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation();
+  };
+
   return (
     <Modal open={open} onClose={onCancel}>
       <ModalHeader>Privacy Settings</ModalHeader>
@@ -44,7 +48,9 @@ const PrivacySettingsModal = (props: Props) => {
           <div className={classNames(styles.checkboxContainer, { selected: allowReporting })}>
             <CheckBox checked={allowReporting} onChange={setAllowReporting} label="Allow error reporting">
               <div className={styles.sentryButton}>
-                <ExternalLink href={links.SENTRY}>Sentry</ExternalLink>{' '}
+                <ExternalLink href={links.SENTRY} onClick={handleEvent} onKeyDown={handleEvent}>
+                  Sentry
+                </ExternalLink>{' '}
                 <img src={images.externalLink} alt="" className={styles.externalLinkIcon} />
               </div>
               collects error data to improve the performance and reliability of our services, and helps us identify and

--- a/src/components/notifications/storage-full-notification.tsx
+++ b/src/components/notifications/storage-full-notification.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { closeAll } from './notifications';
-import { ERROR_REPORTING_CONSENT_KEY_NAME } from '../../utils';
 import styles from './storage-full-notification.module.scss';
+import { ALLOW_ANALYTICS, ALLOW_ERROR_REPORTING } from '../../utils/analytics';
 
 export default function StorageFullNotification() {
   const [busy, setBusy] = useState(false);
@@ -18,10 +18,14 @@ export default function StorageFullNotification() {
           disabled={busy}
           onClick={() => {
             setBusy(true);
-            const errorReportingValue = window.localStorage.getItem(ERROR_REPORTING_CONSENT_KEY_NAME);
+            const errorReportingValue = window.localStorage.getItem(ALLOW_ERROR_REPORTING);
+            const analyticsValue = window.localStorage.getItem(ALLOW_ANALYTICS);
             window.localStorage.clear();
             if (errorReportingValue) {
-              window.localStorage.setItem(ERROR_REPORTING_CONSENT_KEY_NAME, errorReportingValue);
+              window.localStorage.setItem(ALLOW_ERROR_REPORTING, errorReportingValue);
+            }
+            if (analyticsValue) {
+              window.localStorage.setItem(ALLOW_ANALYTICS, analyticsValue);
             }
             window.location.reload();
           }}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,29 +1,9 @@
 import { createRoot } from 'react-dom/client';
-import * as Sentry from '@sentry/react';
 import './index.scss';
 import App from './app';
 import { mockLocalhostWeb3Provider } from './chain-data';
-import { ERROR_REPORTING_CONSENT_KEY_NAME, isErrorReportingAllowed } from './utils';
-
-const errorReportingValue = localStorage.getItem(ERROR_REPORTING_CONSENT_KEY_NAME);
-if (isErrorReportingAllowed(errorReportingValue) && process.env.REACT_APP_SENTRY_DSN) {
-  Sentry.init({
-    dsn: process.env.REACT_APP_SENTRY_DSN,
-    environment: process.env.REACT_APP_NODE_ENV,
-    integrations(integrations) {
-      return integrations.filter((integration) => {
-        // Integrations can be filtered out here
-        // See: https://docs.sentry.io/platforms/javascript/configuration/integrations/default/
-        return !['UserAgent'].includes(integration.name);
-      });
-    },
-    beforeSend(event) {
-      // Do not collect the user's IP address
-      event.user = { ip_address: '0.0.0.0' };
-      return event;
-    },
-  });
-}
+import { canReportErrors, canUseAnalytics, initAnalytics } from './utils/analytics';
+import { initSentry } from './utils/error-reporting';
 
 if (process.env.REACT_APP_NODE_ENV === 'development' && (window as any).ethereum === undefined) {
   mockLocalhostWeb3Provider(window);
@@ -35,3 +15,11 @@ const root = createRoot(document.getElementById('root')!);
 // in our data hooks triggering 3 times on mount (the third trigger is caused by the memoized smart contracts
 // which are included in the useEffect dependency arrays). Because of this, we have decided to turn off strict mode.
 root.render(<App />);
+
+if (canReportErrors()) {
+  initSentry();
+}
+
+if (canUseAnalytics()) {
+  initAnalytics();
+}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,24 @@
+// import TagManager from 'react-gtm-module';
+
+export const ALLOW_ERROR_REPORTING = 'allow-error-reporting';
+export const ALLOW_ANALYTICS = 'allow-analytics';
+
+export const canReportErrors = () => localStorage.getItem(ALLOW_ERROR_REPORTING) === 'true';
+export const canUseAnalytics = () => localStorage.getItem(ALLOW_ANALYTICS) === 'true';
+
+const gtmId = process.env.VITE_APP_GTM_ID || '';
+
+// const tagManagerArgs = {
+//   gtmId,
+// };
+
+let initialised = false;
+export const initAnalytics = () => {
+  if (initialised) return;
+
+  if (gtmId) {
+    // TagManager.initialize(tagManagerArgs); // TBD later
+  }
+
+  initialised = true;
+};

--- a/src/utils/error-reporting.ts
+++ b/src/utils/error-reporting.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 
 let initialised = false;
 export const initSentry = () => {
-  if (initialised) return;
+  if (initialised || !process.env.REACT_APP_SENTRY_DSN) return;
 
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,

--- a/src/utils/error-reporting.ts
+++ b/src/utils/error-reporting.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/react';
+
+let initialised = false;
+export const initSentry = () => {
+  if (initialised) return;
+
+  Sentry.init({
+    dsn: process.env.REACT_APP_SENTRY_DSN,
+    environment: process.env.REACT_APP_NODE_ENV,
+    integrations(integrations) {
+      return integrations.filter((integration) => {
+        // Integrations can be filtered out here
+        // See: https://docs.sentry.io/platforms/javascript/configuration/integrations/default/
+        return !['UserAgent'].includes(integration.name);
+      });
+    },
+    beforeSend(event) {
+      // Do not collect the user's IP address
+      event.user = { ip_address: '0.0.0.0' };
+      return event;
+    },
+  });
+
+  initialised = true;
+};

--- a/src/utils/generic.test.ts
+++ b/src/utils/generic.test.ts
@@ -1,4 +1,4 @@
-import { filterAlphanumerical, getDays, getHours, getMinutes, getSeconds, isErrorReportingAllowed } from './generic';
+import { filterAlphanumerical, getDays, getHours, getMinutes, getSeconds } from './generic';
 
 test('getDays', () => {
   const twelveDays = 1000 * 60 * 60 * 24 * 12;
@@ -36,12 +36,4 @@ test('filterAlphanumerical', () => {
   expect(filterAlphanumerical('\\test\\Red\\Bob-%./"FredNew')).toEqual('testRedBobFredNew');
   expect(filterAlphanumerical('')).toEqual('');
   expect(filterAlphanumerical(' \t\n')).toEqual('');
-});
-
-test('isErrorReportingAllowed', () => {
-  expect(isErrorReportingAllowed(null)).toBe(false);
-  expect(isErrorReportingAllowed('random-value')).toBe(false);
-  expect(isErrorReportingAllowed('false')).toBe(false);
-
-  expect(isErrorReportingAllowed('true')).toBe(true);
 });

--- a/src/utils/generic.ts
+++ b/src/utils/generic.ts
@@ -34,9 +34,3 @@ export const getSeconds = (distance: number) => {
 export const UNKNOWN_NUMBER = '-';
 
 export const filterAlphanumerical = (value: string) => value.replace(/[^0-9a-zA-Z]/g, '');
-
-// Name of the localstorage key that will be used to remember whether the user allowed us to gather error reports
-export const ERROR_REPORTING_CONSENT_KEY_NAME = 'reportErrors';
-export const isErrorReportingAllowed = (localStorageValue: string | null) => {
-  return localStorageValue === Boolean(true).toString();
-};

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,0 +1,4 @@
+export const links = {
+  SENTRY: 'https://sentry.io/',
+  PRIVACY_POLICY: 'https://api3.org/privacy-policy/',
+};


### PR DESCRIPTION
Closes #467 

## What does this do?
- adapts existing consent banner
- implements consent logic from Market
- adds Privacy Settings modal
- adds Checkbox component

## Screenshots

| Banner |
|--------|
| <img width="804" alt="image" src="https://github.com/user-attachments/assets/40be5650-fcb3-40c0-9f11-6081203968dc"> | 

| Modal |
|--------|
| <img width="804" alt="image" src="https://github.com/user-attachments/assets/570c2fb0-2b8c-41ec-a74d-3e0800f62989"> | 
