### PR TITLE
Display proposal title in two lines on non-desktop screens

### DIFF
--- a/src/pages/proposal-commons/proposal-list/proposal-list.module.scss
+++ b/src/pages/proposal-commons/proposal-list/proposal-list.module.scss
@@ -33,7 +33,9 @@
   margin-bottom: 8px;
   text-overflow: ellipsis;
   overflow: hidden;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 
   a {
     color: $color-dark-blue-400;
@@ -42,6 +44,8 @@
   }
 
   @media (min-width: $md) {
+    white-space: nowrap;
+    display: block;
     padding-right: 16px;
     margin-bottom: 4px;
   }


### PR DESCRIPTION
Following the [comment](https://github.com/api3dao/api3-dao-dashboard/pull/499#discussion_r1858058834) and the clarification from designers:

![image](https://github.com/user-attachments/assets/219d0bb3-0324-406b-b935-15f6294575c7)


