### PR TITLE
Change Help tooltip to external link in the New Proposal modal

### DIFF
--- a/src/components/modal/modal.module.scss
+++ b/src/components/modal/modal.module.scss
@@ -132,7 +132,6 @@
 
     &Large {
       justify-content: center;
-      padding-left: 64px;
 
       h5 {
         @include font-heading-6;

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -4,15 +4,13 @@ import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import { useOnAccountOrNetworkChange } from '../../contracts';
 import styles from './modal.module.scss';
-import { CloseIcon, HelpOutlineIcon } from '../icons';
-import Button from '../button';
-import { Tooltip } from '../tooltip';
+import { CloseIcon } from '../icons';
 
-interface ModalSize {
-  size?: 'normal' | 'large';
-}
-interface ModalProps extends ModalSize {
+type ModalSize = 'normal' | 'large';
+
+interface ModalProps {
   children?: React.ReactNode;
+  size?: ModalSize;
   open: boolean;
   onClose: () => void;
   hideCloseButton?: true;
@@ -80,32 +78,17 @@ export const Modal = (props: ModalProps) => {
   return ReactDOM.createPortal(<ModalContent {...props} />, document.getElementById('modal')!);
 };
 
-type ModalHeaderProps =
-  | {
-      children: string;
-      tooltipText?: null;
-      size?: null;
-      noMargin?: boolean;
-    }
-  | {
-      children: string;
-      tooltipText: string;
-      size: 'large';
-      noMargin?: boolean;
-    };
+interface ModalHeaderProps {
+  children: string;
+  size?: ModalSize;
+  noMargin?: boolean;
+}
 
-export const ModalHeader = ({ children, tooltipText, size, noMargin = false }: ModalHeaderProps) => {
+export const ModalHeader = ({ children, size, noMargin = false }: ModalHeaderProps) => {
   if (size === 'large') {
     return (
       <div className={classNames(styles.modalHeader, styles.modalHeaderLarge, { [styles.noMargin]: noMargin })}>
         <h5>{children}</h5>
-
-        <Tooltip overlay={tooltipText}>
-          <Button type="link-blue" size="sm" sm={{ size: 'lg' }}>
-            <HelpOutlineIcon />
-            <span>Help</span>
-          </Button>
-        </Tooltip>
       </div>
     );
   }
@@ -117,7 +100,7 @@ export const ModalHeader = ({ children, tooltipText, size, noMargin = false }: M
   );
 };
 
-interface ModalFooterProps extends ModalSize {
+interface ModalFooterProps {
   children?: React.ReactNode;
   noMargin?: boolean;
 }

--- a/src/pages/proposals/forms/new-proposal-form.module.scss
+++ b/src/pages/proposals/forms/new-proposal-form.module.scss
@@ -1,5 +1,6 @@
 @import '../../../styles/variables.module.scss';
 @import '../../../styles/fonts.module.scss';
+@import '../../../components/button/variants/link-blue.module.scss';
 
 .newProposalModalContent {
   display: flex;
@@ -83,6 +84,30 @@
 
 .noMargin {
   margin: 0;
+}
+
+.helpLinkWrapper {
+  position: absolute;
+  right: 0;
+  top: 8px;
+
+  .helpLink {
+    padding-right: 4px;
+    text-decoration: none;
+    @include link-blue;
+    @include font-link-3;
+  }
+
+  @media (min-width: $sm) {
+    .helpLink {
+      @include font-link-1;
+    }
+
+    img {
+      width: 12px;
+      height: 12px;
+    }
+  }
 }
 
 .newProposalModalFooter {

--- a/src/pages/proposals/forms/new-proposal-form.tsx
+++ b/src/pages/proposals/forms/new-proposal-form.tsx
@@ -12,11 +12,12 @@ import {
   METADATA_SCHEME_VERSION,
 } from '../../../logic/proposals/encoding';
 import { Api3Agent } from '../../../contracts';
-import { filterAlphanumerical } from '../../../utils';
+import { filterAlphanumerical, images } from '../../../utils';
 import styles from './new-proposal-form.module.scss';
 import classNames from 'classnames';
 import { providers } from 'ethers';
 import { InfoCircleIcon } from '../../../components/icons';
+import ExternalLink from '../../../components/external-link';
 
 interface ProposalFormItemProps {
   children: ReactNode;
@@ -99,13 +100,17 @@ const NewProposalForm = (props: Props) => {
 
   return (
     <>
-      <ModalHeader
-        size="large"
-        tooltipText="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam auctor, nunc nec ultricies ultricies, nunc eros ultricies nunc, nec ultricies nunc eros nec ultricies."
-      >
-        New Proposal
-      </ModalHeader>
-
+      <ModalHeader size="large">New Proposal</ModalHeader>
+      <div className={styles.helpLinkWrapper}>
+        <ExternalLink
+          type="link-blue"
+          href="https://dao-docs.api3.org/members/proposals.html"
+          className={styles.helpLink}
+        >
+          Help
+        </ExternalLink>
+        <img src={images.externalLink} alt="" />
+      </div>
       <div className={styles.newProposalModalContent}>
         <ProposalFormItem
           name="Proposal type"
@@ -209,7 +214,7 @@ const NewProposalForm = (props: Props) => {
         </ProposalFormItem>
       </div>
 
-      <ModalFooter size="large">
+      <ModalFooter>
         <div className={styles.newProposalModalFooter}>
           <Button
             type="primary"


### PR DESCRIPTION
First point from the #506 

### What does this change? 
- see title

### Context
- [Designs](https://www.figma.com/design/NG6QClnVrvPRZ5gJ3s0zen/%E2%9F%81--Api3-DAO---Branding-Update?node-id=8676-108151&node-type=frame&m=dev)
- [Discussion](https://api3workspace.slack.com/archives/C06SH3YFMK7/p1732700734669899)

### Screenshot
![image](https://github.com/user-attachments/assets/45b2365e-6e03-49a6-b25d-60bfb390b3a3)
