### PR TITLE
Add privacy links & copyright to the footer

### DIFF
--- a/cypress/e2e/keyboard-navigation.cy.ts
+++ b/cypress/e2e/keyboard-navigation.cy.ts
@@ -24,9 +24,12 @@ describe('keyboard navigation and accessibility', () => {
     pressTabAndAssertFocusOutline(() => cy.findAllByText('Docs').filter(':visible').closest('a'));
 
     pressTabAndAssertFocusOutline(() => cy.findByTestId('connect-wallet-staking-btn'));
-    pressTabAndAssertFocusOutline(() => cy.findByText('About API3'));
+    pressTabAndAssertFocusOutline(() => cy.findByText('Api3.org'));
     pressTabAndAssertFocusOutline(() => cy.findByText('Error Reporting'));
     pressTabAndAssertFocusOutline(() => cy.findByText('Github'));
+    pressTabAndAssertFocusOutline(() => cy.findByText('Privacy Policy'));
+    pressTabAndAssertFocusOutline(() => cy.findByText('Privacy and Cookies'));
+    pressTabAndAssertFocusOutline(() => cy.findByText('Terms and Conditions'));
 
     pressTabAndAssertFocusOutline(() => cy.dataCy('api3-logo')); // Completes the TAB cycle
   });

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -41,11 +41,17 @@
   position: relative;
   align-items: center;
   justify-content: center;
-  height: 196px;
+  height: 244px;
 
-  &Content {
+  &Rows {
+    width: calc(100% - 32px);
+    max-width: 468px;
+  }
+
+  &FirstRow {
     display: flex;
-    padding-top: 44px;
+    padding: 44px 0 24px 0;
+    justify-content: center;
 
     a {
       display: flex;
@@ -76,22 +82,66 @@
       background: $gradient-medium-light;
     }
   }
+
+  &SecondRow {
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: center;
+    gap: 24px;
+    padding: 24px 0 64px 0;
+    border-top: 1px solid $color-blue-25;
+    width: 100%;
+
+    .privacyLinks {
+      display: flex;
+      gap: 16px;
+    }
+
+    a {
+      text-decoration: none;
+      box-sizing: border-box;
+      @include font-overline-2;
+      @include menu-link-secondary;
+    }
+
+    .copyright {
+      @include font-body-18;
+      color: $color-dark-blue-50;
+    }
+  }
 }
 
 @media (min-width: $md) {
   .footer {
-    height: 140px;
+    height: 238px;
 
-    &Content {
-      padding-top: 64px;
+    &Rows {
+      width: calc(100% - 192px);
+      max-width: unset;
+    }
 
-      a {
-        @include font-body-15;
-      }
+    a,
+    .copyright {
+      @include font-body-15;
+    }
 
-      & > *,
+    &FirstRow {
+      padding: 64px 0 32px 0;
+
+      & > button,
       & > a {
-        padding: 0 40px;
+        padding: 0 40px !important;
+      }
+    }
+
+    &SecondRow {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      padding: 32px 0 64px 0;
+
+      .privacyLinks {
+        gap: 24px;
       }
     }
   }

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -35,10 +35,18 @@ export const BaseLayout = ({ children, title }: BaseLayoutProps) => {
   );
 
   const footerLinks = [
-    { text: 'About API3', href: 'https://api3.org/' },
+    { text: 'Api3.org', href: 'https://api3.org/' },
     { text: 'Error Reporting', onClick: () => setShowNotice(true) },
     { text: 'Github', href: 'https://github.com/api3dao/api3-dao-dashboard' },
   ];
+
+  const footerLinksSecondRow = [
+    { text: 'Privacy Policy', href: 'https://api3.org/privacy-policy/' },
+    { text: 'Privacy and Cookies', href: 'https://api3.org/privacy-and-cookies/' },
+    { text: 'Terms and Conditions', href: 'https://api3.org/terms-and-conditions/' },
+  ];
+
+  const actualYear = new Date().getFullYear();
 
   return (
     <>
@@ -56,24 +64,36 @@ export const BaseLayout = ({ children, title }: BaseLayoutProps) => {
           {showNotice ? (
             <ErrorReportingNotice onShowNotice={setShowNotice} />
           ) : (
-            <div className={styles.footerContent}>
-              {footerLinks.map((link) =>
-                link.href ? (
-                  <ExternalLink href={link.href} key={link.text}>
-                    {link.text}
-                  </ExternalLink>
-                ) : (
-                  <Button
-                    key={link.text}
-                    type="menu-link-secondary"
-                    onClick={link.onClick}
-                    size="xs"
-                    md={{ size: 'sm' }}
-                  >
-                    {link.text}
-                  </Button>
-                )
-              )}
+            <div className={styles.footerRows}>
+              <div className={styles.footerFirstRow}>
+                {footerLinks.map((link) =>
+                  link.href ? (
+                    <ExternalLink href={link.href} key={link.text}>
+                      {link.text}
+                    </ExternalLink>
+                  ) : (
+                    <Button
+                      key={link.text}
+                      type="menu-link-secondary"
+                      onClick={link.onClick}
+                      size="xs"
+                      md={{ size: 'sm' }}
+                    >
+                      {link.text}
+                    </Button>
+                  )
+                )}
+              </div>
+              <div className={styles.footerSecondRow}>
+                <div className={styles.copyright}>&copy; {actualYear} API3 Foundation</div>
+                <div className={styles.privacyLinks}>
+                  {footerLinksSecondRow.map((link) => (
+                    <ExternalLink href={link.href} key={link.text}>
+                      {link.text}
+                    </ExternalLink>
+                  ))}
+                </div>
+              </div>
             </div>
           )}
         </footer>

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -8,6 +8,8 @@ import ErrorReportingNotice from './error-reporting-notice';
 import { DesktopMenu } from '../menu';
 import ExternalLink from '../external-link';
 import { ALLOW_ANALYTICS, ALLOW_ERROR_REPORTING } from '../../utils/analytics';
+import { links } from '../../utils/links';
+import { link } from 'fs';
 
 type Props = {
   children: ReactNode;
@@ -35,15 +37,15 @@ export const BaseLayout = ({ children, title }: BaseLayoutProps) => {
   );
 
   const footerLinks = [
-    { text: 'Api3.org', href: 'https://api3.org/' },
+    { text: 'Api3.org', href: links.API3_ORG },
     { text: 'Error Reporting', onClick: () => setShowNotice(true) },
-    { text: 'Github', href: 'https://github.com/api3dao/api3-dao-dashboard' },
+    { text: 'Github', href: links.GITHUB },
   ];
 
   const footerLinksSecondRow = [
-    { text: 'Privacy Policy', href: 'https://api3.org/privacy-policy/' },
-    { text: 'Privacy and Cookies', href: 'https://api3.org/privacy-and-cookies/' },
-    { text: 'Terms and Conditions', href: 'https://api3.org/terms-and-conditions/' },
+    { text: 'Privacy Policy', href: links.PRIVACY_POLICY },
+    { text: 'Privacy and Cookies', href: links.PRIVACY_AND_COOKIES },
+    { text: 'Terms and Conditions', href: links.TERMS_AND_CONDITIONS },
   ];
 
   const actualYear = new Date().getFullYear();

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -9,7 +9,6 @@ import { DesktopMenu } from '../menu';
 import ExternalLink from '../external-link';
 import { ALLOW_ANALYTICS, ALLOW_ERROR_REPORTING } from '../../utils/analytics';
 import { links } from '../../utils/links';
-import { link } from 'fs';
 
 type Props = {
   children: ReactNode;

--- a/src/styles/fonts.module.scss
+++ b/src/styles/fonts.module.scss
@@ -316,7 +316,7 @@
   font-family: Karla;
   font-size: 10px;
   font-style: normal;
-  font-weight: 700;
+  font-weight: 400;
   line-height: 170%; /* 17px */
 }
 

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,4 +1,8 @@
 export const links = {
-  SENTRY: 'https://sentry.io/',
+  API3_ORG: 'https://api3.org/',
+  GITHUB: 'https://github.com/api3dao/api3-dao-dashboard',
+  PRIVACY_AND_COOKIES: 'https://api3.org/privacy-and-cookies/',
   PRIVACY_POLICY: 'https://api3.org/privacy-policy/',
+  SENTRY: 'https://sentry.io/',
+  TERMS_AND_CONDITIONS: 'https://api3.org/terms-and-conditions/',
 };


### PR DESCRIPTION
Closes #521 

### What does this change?
- Changes "About API3" label to just "Api3.org"
- Adds second row to the footer with copyright and links to privacy pages

### Before

![image](https://github.com/user-attachments/assets/be697547-5fcd-455c-ac71-15f04556ce72)


### After

![image](https://github.com/user-attachments/assets/1a66366f-e661-4a18-a986-88e47352d556)
