### PR TITLE
Add CI to deploy to IPFS/upload to Pinata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ REACT_APP_NODE_ENV=development
 REACT_APP_SENTRY_DSN=
 
 # Wallet Connect project ID
-REACT_APP_PROJECT_ID=e7e6e90622ec8e65c4d02e829a68529a
+REACT_APP_PROJECT_ID=8bddccf51318f114759f31306090233e
 
 # The RPC URL will be visible in the browser network tab (leaking the API key). It is advised to whitelist only Api3 DAO
 # contracts making the RPC URL useless for others. To support Wallet Connect with MM wallet without errors a few

--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -1,0 +1,62 @@
+name: Deploy to IPFS
+
+on:
+  push:
+    branches:
+      # TODO: Swap to "production" before merging
+      - ci-pinata-upload
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-to-ipfs
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone api3-dao-dashboard
+        uses: actions/checkout@v6
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - name: Install Dependencies
+        run: pnpm install
+      - name: Build
+        env:
+          REACT_APP_NODE_ENV: production
+          REACT_APP_PROJECT_ID: 8bddccf51318f114759f31306090233e
+          REACT_APP_SENTRY_DSN: ${{ secrets.REACT_APP_SENTRY_DSN }}
+          REACT_APP_MAINNET_PROVIDER_URL: ${{ secrets.REACT_APP_MAINNET_PROVIDER_URL }}
+        run: pnpm build
+      - name: Upload to Pinata
+        id: upload
+        env:
+          PINATA_JWT: ${{ secrets.PINATA_JWT }}
+        run: pnpm upload-build-to-pinata
+      - name: Verify CID
+        env:
+          PINATA_CID: ${{ steps.upload.outputs.cid }}
+        run: |
+          LOCAL_CID=$(docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive --quieter /build)
+          echo "Pinata CID: $PINATA_CID"
+          echo "Local CID:  $LOCAL_CID"
+          # Both CIDs are v0 ("Qm...")
+          if [ "$LOCAL_CID" != "$PINATA_CID" ]; then
+            echo "::error::CID mismatch between the Pinata upload and the local build"
+            exit 1
+          fi
+          CID_V1=$(docker run --rm ipfs/kubo cid format -v 1 -b base32 "$PINATA_CID")
+          {
+            echo "## IPFS deployment"
+            echo ""
+            echo "CID (v0): \`$PINATA_CID\`"
+            echo ""
+            echo "CID (v1): \`$CID_V1\`"
+            echo ""
+            echo "Use the v1 CID to update the api3.eth ENS content hash (see dev-README.md)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -14,6 +14,9 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name == 'production' && 'production' || 'preview' }}
+      url: ${{ format('https://{0}.ipfs.dweb.link', steps.verify.outputs.cid-v1) }}
     steps:
       - name: Clone api3-dao-dashboard
         uses: actions/checkout@v6
@@ -39,6 +42,7 @@ jobs:
           PINATA_JWT: ${{ secrets.PINATA_JWT }}
         run: pnpm upload-build-to-pinata
       - name: Verify CID
+        id: verify
         env:
           PINATA_CID: ${{ steps.upload.outputs.cid }}
         run: |
@@ -51,12 +55,15 @@ jobs:
             exit 1
           fi
           CID_V1=$(docker run --rm ipfs/kubo cid format -v 1 -b base32 "$PINATA_CID" | tail -n 1)
+          echo "cid-v1=$CID_V1" >> "$GITHUB_OUTPUT"
           {
-            echo "## IPFS deployment"
+            echo "## Deployed successfully"
             echo ""
-            echo "CID (v0): \`$PINATA_CID\`"
-            echo ""
-            echo "CID (v1): \`$CID_V1\`"
-            echo ""
-            echo "Use the v1 CID to update the api3.eth ENS content hash (see dev-README.md)."
+            echo "|  |  |"
+            echo "| --- | --- |"
+            echo "| **Latest commit:** | \`${GITHUB_SHA::7}\` |"
+            echo "| **Status:** | ✅ Deploy successful! |"
+            echo "| **CID (v0):** | \`$PINATA_CID\` |"
+            echo "| **CID (v1):** | \`$CID_V1\` |"
+            echo "| **Preview URL:** | https://$CID_V1.ipfs.dweb.link |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           PINATA_CID: ${{ steps.upload.outputs.cid }}
         run: |
-          LOCAL_CID=$(docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive --quieter /build)
+          LOCAL_CID=$(docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive --quieter /build | tail -n 1)
           echo "Pinata CID: $PINATA_CID"
           echo "Local CID:  $LOCAL_CID"
           # Both CIDs are v0 ("Qm...")
@@ -50,7 +50,7 @@ jobs:
             echo "::error::CID mismatch between the Pinata upload and the local build"
             exit 1
           fi
-          CID_V1=$(docker run --rm ipfs/kubo cid format -v 1 -b base32 "$PINATA_CID")
+          CID_V1=$(docker run --rm ipfs/kubo cid format -v 1 -b base32 "$PINATA_CID" | tail -n 1)
           {
             echo "## IPFS deployment"
             echo ""

--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.ref_name == 'production' && 'production' || 'preview' }}
-      url: ${{ format('https://{0}/ipfs/{1}', vars.PINATA_GATEWAY_DOMAIN, steps.verify.outputs.cid-v1) }}
     steps:
       - name: Clone api3-dao-dashboard
         uses: actions/checkout@v6
@@ -42,10 +41,8 @@ jobs:
           PINATA_JWT: ${{ secrets.PINATA_JWT }}
         run: pnpm upload-build-to-pinata
       - name: Verify CID
-        id: verify
         env:
           PINATA_CID: ${{ steps.upload.outputs.cid }}
-          PINATA_GATEWAY_DOMAIN: ${{ vars.PINATA_GATEWAY_DOMAIN }}
         run: |
           LOCAL_CID=$(docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive --quieter /build | tail -n 1)
           echo "Pinata CID: $PINATA_CID"
@@ -56,7 +53,6 @@ jobs:
             exit 1
           fi
           CID_V1=$(docker run --rm ipfs/kubo cid format -v 1 -b base32 "$PINATA_CID" | tail -n 1)
-          echo "cid-v1=$CID_V1" >> "$GITHUB_OUTPUT"
           {
             echo "## Deployed successfully"
             echo ""
@@ -66,5 +62,4 @@ jobs:
             echo "| **Status:** | ✅ Deploy successful! |"
             echo "| **CID (v0):** | \`$PINATA_CID\` |"
             echo "| **CID (v1):** | \`$CID_V1\` |"
-            echo "| **Preview URL:** | https://$PINATA_GATEWAY_DOMAIN/ipfs/$CID_V1 |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Clone api3-dao-dashboard
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.ref_name == 'production' && 'production' || 'preview' }}
-      url: ${{ format('https://{0}.ipfs.dweb.link', steps.verify.outputs.cid-v1) }}
+      url: ${{ format('https://{0}/ipfs/{1}', vars.PINATA_GATEWAY_DOMAIN, steps.verify.outputs.cid-v1) }}
     steps:
       - name: Clone api3-dao-dashboard
         uses: actions/checkout@v6
@@ -45,6 +45,7 @@ jobs:
         id: verify
         env:
           PINATA_CID: ${{ steps.upload.outputs.cid }}
+          PINATA_GATEWAY_DOMAIN: ${{ vars.PINATA_GATEWAY_DOMAIN }}
         run: |
           LOCAL_CID=$(docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive --quieter /build | tail -n 1)
           echo "Pinata CID: $PINATA_CID"
@@ -65,5 +66,5 @@ jobs:
             echo "| **Status:** | ✅ Deploy successful! |"
             echo "| **CID (v0):** | \`$PINATA_CID\` |"
             echo "| **CID (v1):** | \`$CID_V1\` |"
-            echo "| **Preview URL:** | https://$CID_V1.ipfs.dweb.link |"
+            echo "| **Preview URL:** | https://$PINATA_GATEWAY_DOMAIN/ipfs/$CID_V1 |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -3,8 +3,7 @@ name: Deploy to IPFS
 on:
   push:
     branches:
-      # TODO: Swap to "production" before merging
-      - ci-pinata-upload
+      - production
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Clone api3-dao-dashboard
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Clone api3-dao-dashboard
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Cypress tests
         env:
           REACT_APP_NODE_ENV: development
-          REACT_APP_PROJECT_ID: e7e6e90622ec8e65c4d02e829a68529a
+          REACT_APP_PROJECT_ID: 8bddccf51318f114759f31306090233e
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           REACT_APP_MAINNET_PROVIDER_URL: ${{ secrets.REACT_APP_MAINNET_PROVIDER_URL }}
         run: pnpm percy exec -- pnpm ci:cypress

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG REACT_APP_MAINNET_PROVIDER_URL
 ENV REACT_APP_MAINNET_PROVIDER_URL=$REACT_APP_MAINNET_PROVIDER_URL
 # The Wallet Connect project ID is required at build time, and it is OK to hardcode because the project ID
 # is discoverable when using the dApp.
-ENV REACT_APP_PROJECT_ID=0b2e430162b0e6c93619b3d65cf90d4e
+ENV REACT_APP_PROJECT_ID=8bddccf51318f114759f31306090233e
 RUN apk add --update --no-cache git $([ $(arch) == "aarch64" ] && echo "python3 make g++")
 RUN corepack enable && corepack prepare pnpm@10.26.2 --activate
 WORKDIR /usr/src/app

--- a/dev-README.md
+++ b/dev-README.md
@@ -39,22 +39,31 @@ Currently, there are no preview builds.
 
 ### Updating the production deployment
 
-All you need to do is push the code to the `production` branch. The simplest way is to open a PR from the `main` branch
-and merge. Afterwards, proceed to create a manual IPFS deployment. Full process:
+The upload to Pinata happens automatically in CI. Full process:
 
 1. Open a PR from `main` to `production`, wait for CI to pass and merge
-2. Run `git checkout production` to check out the production branch locally
-3. Run `git pull` to pull the latest changes
-4. Populate `.env.production.local` with production secrets
-5. Run `pnpm install` to install the latest dependencies
-6. Run `pnpm build` to create the production build
-7. Run `PINATA_JWT=<JWT> pnpm upload-build-to-pinata` to upload the build folder to Pinata
-8. Run `docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive /build` to verify the CID hash of
-   the build folder with the deployed hash on Pinata
-9. Verify the uploaded page by clicking on the uploaded "build" row on the UI (differentiated by CID if there are
+2. The merge triggers the "Deploy to IPFS" GitHub Actions workflow, which builds the app, uploads the build folder to
+   Pinata and verifies that the CID reported by Pinata matches the CID of the build computed locally in CI
+3. Open the workflow run and find the deployed CID in the run summary
+4. Verify the uploaded page by clicking on the uploaded "build" row on the Pinata UI (differentiated by CID if there are
    multiple) and make sure it loads - the fonts may look strange, but that's only because of security policies defined
    by the Pinata preview site and they will work without issues when used via ENS
-10. Refer to the "Updating the name servers" section below to update the ENS name
+5. Refer to the "Updating the name servers" section below to update the ENS name
+
+The workflow can also be re-run manually from the GitHub Actions UI (e.g. after a transient upload failure).
+
+#### Manual upload (fallback)
+
+If CI is unavailable, you can upload the build manually:
+
+1. Run `git checkout production` to check out the production branch locally
+2. Run `git pull` to pull the latest changes
+3. Populate `.env.production.local` with production secrets
+4. Run `pnpm install` to install the latest dependencies
+5. Run `pnpm build` to create the production build
+6. Run `PINATA_JWT=<JWT> pnpm upload-build-to-pinata` to upload the build folder to Pinata
+7. Run `docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive /build` to verify the CID hash of
+   the build folder with the deployed hash on Pinata
 
 #### Updating the name servers
 

--- a/dev-README.md
+++ b/dev-README.md
@@ -44,9 +44,10 @@ The upload to Pinata happens automatically in CI. Full process:
 1. Open a PR from `main` to `production`, wait for CI to pass and merge
 2. The merge triggers the "Deploy to IPFS" GitHub Actions workflow, which builds the app, uploads the build folder to
    Pinata and verifies that the CID reported by Pinata matches the CID of the build computed locally in CI
-3. Open the workflow run summary, which shows the deployed CID (in both v0 and v1 form) and a preview URL
-4. Verify that the preview loads - the fonts may look strange, but that's only because of security policies defined by
-   the gateway and they will work without issues when used via ENS
+3. Open the workflow run summary, which shows the deployed CID (in both v0 and v1 form)
+4. Verify the upload at https://app.pinata.cloud/ipfs/files. There should be an entry for the CID. Click the "build"
+   link and make sure it loads - the fonts may look strange, but that's only because of security policies defined by the
+   gateway and they will work without issues when used via ENS
 5. Refer to the "Updating the name servers" section below to update the ENS name
 
 The workflow can also be re-run manually from the GitHub Actions UI.
@@ -63,8 +64,6 @@ If CI is unavailable, you can upload the build manually:
 6. Run `PINATA_JWT=<JWT> pnpm upload-build-to-pinata` to upload the build folder to Pinata
 7. Run `docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive /build` to verify the CID hash of
    the build folder with the deployed hash on Pinata
-8. Verify the upload at https://app.pinata.cloud/ipfs/files. There should be an entry for the CID. Click the "build"
-   link and make sure it loads.
 
 #### Updating the name servers
 

--- a/dev-README.md
+++ b/dev-README.md
@@ -44,13 +44,12 @@ The upload to Pinata happens automatically in CI. Full process:
 1. Open a PR from `main` to `production`, wait for CI to pass and merge
 2. The merge triggers the "Deploy to IPFS" GitHub Actions workflow, which builds the app, uploads the build folder to
    Pinata and verifies that the CID reported by Pinata matches the CID of the build computed locally in CI
-3. Open the workflow run and find the deployed CID in the run summary
-4. Verify the uploaded page by clicking on the uploaded "build" row on the Pinata UI (differentiated by CID if there are
-   multiple) and make sure it loads - the fonts may look strange, but that's only because of security policies defined
-   by the Pinata preview site and they will work without issues when used via ENS
+3. Open the workflow run summary, which shows the deployed CID (in both v0 and v1 form) and a preview URL
+4. Verify that the preview loads - the fonts may look strange, but that's only because of security policies defined by
+   the gateway and they will work without issues when used via ENS
 5. Refer to the "Updating the name servers" section below to update the ENS name
 
-The workflow can also be re-run manually from the GitHub Actions UI (e.g. after a transient upload failure).
+The workflow can also be re-run manually from the GitHub Actions UI.
 
 #### Manual upload (fallback)
 
@@ -64,6 +63,8 @@ If CI is unavailable, you can upload the build manually:
 6. Run `PINATA_JWT=<JWT> pnpm upload-build-to-pinata` to upload the build folder to Pinata
 7. Run `docker run --rm -v "$(pwd)/build:/build" ipfs/kubo add --only-hash --recursive /build` to verify the CID hash of
    the build folder with the deployed hash on Pinata
+8. Verify the upload at https://app.pinata.cloud/ipfs/files. There should be an entry for the CID. Click the "build"
+   link and make sure it loads.
 
 #### Updating the name servers
 

--- a/dev-scripts/upload-build-to-pinata.mjs
+++ b/dev-scripts/upload-build-to-pinata.mjs
@@ -65,6 +65,14 @@ const uploadBuildToPinata = async () => {
   const result = await response.json();
   console.info('✅ Success!');
   console.info(result);
+
+  // Expose the CID to later workflow steps when running in GitHub Actions
+  if (process.env.GITHUB_OUTPUT) {
+    await fs.promises.appendFile(process.env.GITHUB_OUTPUT, `cid=${result.IpfsHash}\n`);
+  }
 };
 
-uploadBuildToPinata().catch(console.error);
+uploadBuildToPinata().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #557 

The CI emits a summary (Cloudflare vibe) to make it easier to get the relevant information:
<img width="889" height="318" alt="Screenshot 2026-08-17 at 17 09 38" src="https://github.com/user-attachments/assets/5dcf9653-1099-4626-864b-d40669568dcb" />
E.g. https://github.com/api3dao/api3-dao-dashboard/actions/runs/32041149537

Each run also creates a GH deployment: https://github.com/api3dao/api3-dao-dashboard/deployments
